### PR TITLE
reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
+# from .gitignore
 venv/
 ui/__pycache__/
 outputs/
 modules/__pycache__/
 models/
 modules/yt_tmp.wav
+
+.git
+.github

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-# from .gitignore
 venv/
 ui/__pycache__/
 outputs/
 modules/__pycache__/
 models/
 modules/yt_tmp.wav
-
-.git
-.github

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# from .gitignore
 venv/
 ui/__pycache__/
 outputs/
 modules/__pycache__/
 models/
 modules/yt_tmp.wav
+
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,34 @@
-FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04 AS runtime
-
-VOLUME [ "/Whisper-WebUI/models" ]
-VOLUME [ "/Whisper-WebUI/outputs" ]
+FROM debian:bookworm-slim AS builder
 
 RUN apt-get update && \
-    apt-get install -y curl ffmpeg git python3 python3-pip python3-venv && \
+    apt-get install -y curl git python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     mkdir -p /Whisper-WebUI
 
 WORKDIR /Whisper-WebUI
 
-COPY . .
+COPY requirements.txt .
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \
     pip install --no-cache-dir -r requirements.txt
 
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && \
+    apt-get install -y curl ffmpeg python3 && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+WORKDIR /Whisper-WebUI
+
+COPY . .
+COPY --from=builder /Whisper-WebUI/venv /Whisper-WebUI/venv
+
+VOLUME [ "/Whisper-WebUI/models" ]
+VOLUME [ "/Whisper-WebUI/outputs" ]
+
 ENV PATH="/Whisper-WebUI/venv/bin:$PATH"
-ENV LD_LIBRARY_PATH=/Whisper-WebUI/venv/lib64/python3.10/site-packages/nvidia/cublas/lib:/Whisper-WebUI/venv/lib64/python3.10/site-packages/nvidia/cudnn/lib
+ENV LD_LIBRARY_PATH=/Whisper-WebUI/venv/lib64/python3.11/site-packages/nvidia/cublas/lib:/Whisper-WebUI/venv/lib64/python3.11/site-packages/nvidia/cudnn/lib
 
 ENTRYPOINT [ "python", "app.py" ]


### PR DESCRIPTION
The size has been reduced from 10G+ to 6G+ by

- change base image nvidia/cuda:12 to debian:bookworm-slim
- refactor to multi-stage build

Other changes(may not have affect):

- default python version 3.10 -> 3.11
- some tweaks in copy operation.