### PR TITLE
Fix typing errors

### DIFF
--- a/modules/faster_whisper_inference.py
+++ b/modules/faster_whisper_inference.py
@@ -339,7 +339,7 @@ class FasterWhisperInference(BaseInterface):
 
         Returns
         ----------
-        segments_result: list[dict]
+        segments_result: List[dict]
             list of dicts that includes start, end timestamps and transcribed text
         elapsed_time: float
             elapsed time for transcription

--- a/modules/faster_whisper_inference.py
+++ b/modules/faster_whisper_inference.py
@@ -3,7 +3,7 @@ import os
 import tqdm
 import time
 import numpy as np
-from typing import BinaryIO, Union, Tuple
+from typing import BinaryIO, Union, Tuple, List
 from datetime import datetime, timedelta
 
 import faster_whisper
@@ -312,7 +312,7 @@ class FasterWhisperInference(BaseInterface):
                    log_prob_threshold: float,
                    no_speech_threshold: float,
                    progress: gr.Progress
-                   ) -> Tuple[list, float]:
+                   ) -> Tuple[List[dict], float]:
         """
         transcribe method for faster-whisper.
 

--- a/modules/whisper_Inference.py
+++ b/modules/whisper_Inference.py
@@ -2,7 +2,7 @@ import whisper
 import gradio as gr
 import time
 import os
-from typing import BinaryIO, Union, Tuple
+from typing import BinaryIO, Union, Tuple, List
 import numpy as np
 from datetime import datetime
 import torch
@@ -302,7 +302,7 @@ class WhisperInference(BaseInterface):
                    no_speech_threshold: float,
                    compute_type: str,
                    progress: gr.Progress
-                   ) -> Tuple[list[dict], float]:
+                   ) -> Tuple[List[dict], float]:
         """
         transcribe method for OpenAI's Whisper implementation.
 
@@ -331,7 +331,7 @@ class WhisperInference(BaseInterface):
 
         Returns
         ----------
-        segments_result: list[dict]
+        segments_result: List[dict]
             list of dicts that includes start, end timestamps and transcribed text
         elapsed_time: float
             elapsed time for transcription


### PR DESCRIPTION
To resolve 
- #65 

`list[str]` is only valid from Python 3.9

Reference
- https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python
- https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections
