### PR TITLE
add `api_open`

### DIFF
--- a/app.py
+++ b/app.py
@@ -266,6 +266,7 @@ parser.add_argument('--username', type=str, default=None, help='Gradio authentic
 parser.add_argument('--password', type=str, default=None, help='Gradio authentication password')
 parser.add_argument('--theme', type=str, default=None, help='Gradio Blocks theme')
 parser.add_argument('--colab', type=bool, default=False, nargs='?', const=True, help='Is colab user or not')
+parser.add_argument('--api_open', type=bool, default=False, nargs='?', const=True, help='enable api or not')
 _args = parser.parse_args()
 
 if __name__ == "__main__":

--- a/user-start-webui.bat
+++ b/user-start-webui.bat
@@ -9,8 +9,7 @@ set PASSWORD=
 set SHARE=
 set THEME=
 set DISABLE_FASTER_WHISPER=
-
-
+set API_OPEN=
 
 
 :: Set args accordingly
@@ -35,7 +34,10 @@ if not "%THEME%"=="" (
 if /I "%DISABLE_FASTER_WHISPER%"=="true" (
     set DISABLE_FASTER_WHISPER_ARG=--disable_faster_whisper
 )
+if /I "%API_OPEN%"=="true" (
+    set API_OPEN=--api_open
+)
 
 :: Call the original .bat script with optional arguments
-start-webui.bat %SERVER_NAME_ARG% %SERVER_PORT_ARG% %USERNAME_ARG% %PASSWORD_ARG% %SHARE_ARG% %THEME_ARG% %DISABLE_FASTER_WHISPER_ARG%
+start-webui.bat %SERVER_NAME_ARG% %SERVER_PORT_ARG% %USERNAME_ARG% %PASSWORD_ARG% %SHARE_ARG% %THEME_ARG% %DISABLE_FASTER_WHISPER_ARG% %API_OPEN%
 pause


### PR DESCRIPTION
According to the [documentation](https://www.gradio.app/docs/interface#interface-queue-arguments), this allows to requests to be processed directly, skipping the queue.

You can still use the API without this, but it's better to include it as an argument.

- related issue:
    - #137 