### PR TITLE
Fix `get_device()`

### DIFF
--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -145,7 +145,5 @@ class FasterWhisperInference(WhisperBase):
     def get_device():
         if torch.cuda.is_available():
             return "cuda"
-        elif torch.backends.mps.is_available():
-            return "auto"
         else:
-            return "cpu"
+            return "auto"


### PR DESCRIPTION
Related issues:
- #192

Changed:
1. Just set the device to "auto" if not cuda