### PR TITLE
Migrate faster whisper to 1.0.3

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,7 +115,6 @@ class App:
                         nb_min_speech_duration_ms = gr.Number(label="Minimum Speech Duration (ms)", precision=0, value=250)
                         nb_max_speech_duration_s = gr.Number(label="Maximum Speech Duration (s)", value=9999)
                         nb_min_silence_duration_ms = gr.Number(label="Minimum Silence Duration (ms)", precision=0, value=2000)
-                        nb_window_size_sample = gr.Number(label="Window Size (samples)", precision=0, value=1024)
                         nb_speech_pad_ms = gr.Number(label="Speech Padding (ms)", precision=0, value=400)
                     with gr.Accordion("Diarization", open=False):
                         cb_diarize = gr.Checkbox(label="Enable Diarization")
@@ -152,7 +151,6 @@ class App:
                                                        min_speech_duration_ms=nb_min_speech_duration_ms,
                                                        max_speech_duration_s=nb_max_speech_duration_s,
                                                        min_silence_duration_ms=nb_min_silence_duration_ms,
-                                                       window_size_sample=nb_window_size_sample,
                                                        speech_pad_ms=nb_speech_pad_ms,
                                                        chunk_length_s=nb_chunk_length_s,
                                                        batch_size=nb_batch_size,
@@ -203,7 +201,6 @@ class App:
                         nb_min_speech_duration_ms = gr.Number(label="Minimum Speech Duration (ms)", precision=0, value=250)
                         nb_max_speech_duration_s = gr.Number(label="Maximum Speech Duration (s)", value=9999)
                         nb_min_silence_duration_ms = gr.Number(label="Minimum Silence Duration (ms)", precision=0, value=2000)
-                        nb_window_size_sample = gr.Number(label="Window Size (samples)", precision=0, value=1024)
                         nb_speech_pad_ms = gr.Number(label="Speech Padding (ms)", precision=0, value=400)
                     with gr.Accordion("Diarization", open=False):
                         cb_diarize = gr.Checkbox(label="Enable Diarization")
@@ -241,7 +238,6 @@ class App:
                                                        min_speech_duration_ms=nb_min_speech_duration_ms,
                                                        max_speech_duration_s=nb_max_speech_duration_s,
                                                        min_silence_duration_ms=nb_min_silence_duration_ms,
-                                                       window_size_sample=nb_window_size_sample,
                                                        speech_pad_ms=nb_speech_pad_ms,
                                                        chunk_length_s=nb_chunk_length_s,
                                                        batch_size=nb_batch_size,
@@ -284,7 +280,6 @@ class App:
                         nb_min_speech_duration_ms = gr.Number(label="Minimum Speech Duration (ms)", precision=0, value=250)
                         nb_max_speech_duration_s = gr.Number(label="Maximum Speech Duration (s)", value=9999)
                         nb_min_silence_duration_ms = gr.Number(label="Minimum Silence Duration (ms)", precision=0, value=2000)
-                        nb_window_size_sample = gr.Number(label="Window Size (samples)", precision=0, value=1024)
                         nb_speech_pad_ms = gr.Number(label="Speech Padding (ms)", precision=0, value=400)
                     with gr.Accordion("Diarization", open=False):
                         cb_diarize = gr.Checkbox(label="Enable Diarization")
@@ -324,7 +319,6 @@ class App:
                                                        min_speech_duration_ms=nb_min_speech_duration_ms,
                                                        max_speech_duration_s=nb_max_speech_duration_s,
                                                        min_silence_duration_ms=nb_min_silence_duration_ms,
-                                                       window_size_sample=nb_window_size_sample,
                                                        speech_pad_ms=nb_speech_pad_ms,
                                                        chunk_length_s=nb_chunk_length_s,
                                                        batch_size=nb_batch_size,

--- a/modules/vad/silero_vad.py
+++ b/modules/vad/silero_vad.py
@@ -78,6 +78,9 @@ class SileroVAD:
         if self.model is None:
             self.update_model()
 
+        if vad_options is None:
+            vad_options = VadOptions(**kwargs)
+
         threshold = vad_options.threshold
         min_speech_duration_ms = vad_options.min_speech_duration_ms
         max_speech_duration_s = vad_options.max_speech_duration_s

--- a/modules/whisper/whisper_base.py
+++ b/modules/whisper/whisper_base.py
@@ -91,7 +91,6 @@ class WhisperBase(ABC):
                 min_speech_duration_ms=params.min_speech_duration_ms,
                 max_speech_duration_s=params.max_speech_duration_s,
                 min_silence_duration_ms=params.min_silence_duration_ms,
-                window_size_samples=params.window_size_samples,
                 speech_pad_ms=params.speech_pad_ms
             )
             self.vad.run(

--- a/modules/whisper/whisper_parameter.py
+++ b/modules/whisper/whisper_parameter.py
@@ -23,7 +23,6 @@ class WhisperParameters:
     min_speech_duration_ms: gr.Number
     max_speech_duration_s: gr.Number
     min_silence_duration_ms: gr.Number
-    window_size_sample: gr.Number
     speech_pad_ms: gr.Number
     chunk_length_s: gr.Number
     batch_size: gr.Number
@@ -111,11 +110,6 @@ class WhisperParameters:
         This parameter is related with Silero VAD. In the end of each speech chunk wait for min_silence_duration_ms
         before separating it
         
-    window_size_samples: gr.Number
-        This parameter is related with Silero VAD. Audio chunks of window_size_samples size are fed to the silero VAD model.
-        WARNING! Silero VAD models were trained using 512, 1024, 1536 samples for 16000 sample rate.
-        Values other than these may affect model performance!!
-        
     speech_pad_ms: gr.Number
         This parameter is related with Silero VAD. Final speech chunks are padded by speech_pad_ms each side    
         
@@ -178,13 +172,12 @@ class WhisperParameters:
             min_speech_duration_ms=args[15],
             max_speech_duration_s=args[16],
             min_silence_duration_ms=args[17],
-            window_size_samples=args[18],
-            speech_pad_ms=args[19],
-            chunk_length_s=args[20],
-            batch_size=args[21],
-            is_diarize=args[22],
-            hf_token=args[23],
-            diarization_device=args[24]
+            speech_pad_ms=args[18],
+            chunk_length_s=args[19],
+            batch_size=args[20],
+            is_diarize=args[21],
+            hf_token=args[22],
+            diarization_device=args[23]
         )
 
 
@@ -208,7 +201,6 @@ class WhisperValues:
     min_speech_duration_ms: int
     max_speech_duration_s: float
     min_silence_duration_ms: int
-    window_size_samples: int
     speech_pad_ms: int
     chunk_length_s: int
     batch_size: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch
 git+https://github.com/jhj0517/jhj0517-whisper.git
-faster-whisper==1.0.2
+faster-whisper==1.0.3
 transformers
 gradio==4.29.0
 pytube


### PR DESCRIPTION
## Related Issues
- #197 

## Changed
1. Migrate faster-whisper to 1.0.3
2. Removed deprecated parameter `window_size_sample`