### PR TITLE
Add option to silence non-speech segments in VAD instead of cutting off

### DIFF
--- a/modules/vad/silero_vad.py
+++ b/modules/vad/silero_vad.py
@@ -240,15 +240,15 @@ class SileroVAD:
         Returns:
           Tuple containing:
             - Processed audio as a numpy array
-            - Duration of changed (silenced or removed) audio in seconds
+            - Duration of non-speech (silenced or removed) audio in seconds
         """
         if not chunks:
             return np.array([], dtype=np.float32), 0.0
 
         total_samples = audio.shape[0]
-        speech_samples = sum(chunk["end"] - chunk["start"] for chunk in chunks)
-        changed_samples = total_samples - speech_samples
-        duration_difference = changed_samples / self.sampling_rate
+        speech_samples_count = sum(chunk["end"] - chunk["start"] for chunk in chunks)
+        non_speech_samples_count = total_samples - speech_samples_count
+        non_speech_duration = non_speech_samples_count / self.sampling_rate
 
         if not silence_non_speech:
             processed_audio = np.concatenate([audio[chunk["start"]: chunk["end"]] for chunk in chunks])
@@ -258,7 +258,7 @@ class SileroVAD:
                 start, end = chunk['start'], chunk['end']
                 processed_audio[start:end] = audio[start:end]
 
-        return processed_audio, duration_difference
+        return processed_audio, non_speech_duration
 
     @staticmethod
     def format_timestamp(

--- a/modules/whisper/whisper_base.py
+++ b/modules/whisper/whisper_base.py
@@ -96,6 +96,7 @@ class WhisperBase(ABC):
             audio = self.vad.run(
                 audio=audio,
                 vad_parameters=vad_options,
+                silence_non_speech=True,
                 progress=progress
             )
 


### PR DESCRIPTION
## Related issues
- #212

## Changed
1. Added `silence_non_speech` parameter to VAD processing. When it's `True`, non-speech segments are silenced instead of cutting off.
2. Updated `collect_chunks()` accordingly
