### PR TITLE
Fix missing initial prompt parameter

### DIFF
--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -86,6 +86,7 @@ class FasterWhisperInference(WhisperBase):
             best_of=params.best_of,
             patience=params.patience,
             temperature=params.temperature,
+            initial_prompt=params.initial_prompt,
             compression_ratio_threshold=params.compression_ratio_threshold,
             length_penalty=params.length_penalty,
             repetition_penalty=params.repetition_penalty,


### PR DESCRIPTION
Initial prompt should be included in the transcribe function otherwise the field won't do anything when filled out in the web ui.