### PR TITLE
Update default version of the CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you wish to try this on Colab, you can do it in [here](https://colab.research
 # Installation and Running
 ### Prerequisite
 To run this WebUI, you need to have `git`, `python` version 3.8 ~ 3.10, `FFmpeg`. <br>
-And if you're not using an Nvida GPU, or using a different `CUDA` version than 12.1,  edit the [`requirements.txt`](https://github.com/jhj0517/Whisper-WebUI/blob/master/requirements.txt) to match your environment.
+And if you're not using an Nvida GPU, or using a different `CUDA` version than 12.4,  edit the [`requirements.txt`](https://github.com/jhj0517/Whisper-WebUI/blob/master/requirements.txt) to match your environment.
 
 Please follow the links below to install the necessary software:
 - git : [https://git-scm.com/downloads](https://git-scm.com/downloads)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@
 # If you're using it, update url to your CUDA version (CUDA 12.1 is minimum requirement):
 # For CUDA 12.1, use : https://download.pytorch.org/whl/cu121
 # For CUDA 12.4, use : https://download.pytorch.org/whl/cu124
+--extra-index-url https://download.pytorch.org/whl/cu124
 
---extra-index-url https://download.pytorch.org/whl/cu121
+
 torch
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.0.3


### PR DESCRIPTION
## Related issues
- https://github.com/pytorch/pytorch/issues/131662#issuecomment-2322909778

CUDA 12.1 & latest `torch` is problematic in Windows 11.

## Changed

1.  Update default CUDA to 12.4