### PR TITLE
Handle `SparseMPS` device

### DIFF
--- a/modules/whisper/whisper_base.py
+++ b/modules/whisper/whisper_base.py
@@ -467,7 +467,7 @@ class WhisperBase(ABC):
 
     @staticmethod
     def is_sparse_api_supported():
-        if torch.backends.mps.is_available():
+        if not torch.backends.mps.is_available():
             return False
 
         try:

--- a/modules/whisper/whisper_base.py
+++ b/modules/whisper/whisper_base.py
@@ -453,19 +453,20 @@ class WhisperBase(ABC):
 
         return time_str.strip()
 
-    def get_device(self):
+    @staticmethod
+    def get_device():
         if torch.cuda.is_available():
             return "cuda"
         elif torch.backends.mps.is_available():
-            if self.is_sparse_mps_supported():
-                # MPS is not supported for sparse tensor for now. See : https://github.com/pytorch/pytorch/issues/87886
+            if not WhisperBase.is_sparse_api_supported():
+                # Device `SparseMPS` is not supported for now. See : https://github.com/pytorch/pytorch/issues/87886
                 return "cpu"
             return "mps"
         else:
             return "cpu"
 
     @staticmethod
-    def is_sparse_mps_supported():
+    def is_sparse_api_supported():
         if torch.backends.mps.is_available():
             return False
 


### PR DESCRIPTION
## Related issue
- #276 
- https://github.com/pytorch/pytorch/issues/87886
## Changed
1. Use just `cpu` for `SparseMPS` device.