### PR TITLE
Update cache clean up logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from modules.whisper.whisper_parameter import *
 class App:
     def __init__(self, args):
         self.args = args
-        self.app = gr.Blocks(css=CSS, theme=self.args.theme)
+        self.app = gr.Blocks(css=CSS, theme=self.args.theme, delete_cache=(60, 3600))
         self.whisper_inf = WhisperFactory.create_whisper_inference(
             whisper_type=self.args.whisper_type,
             whisper_model_dir=self.args.whisper_model_dir,

--- a/modules/whisper/whisper_base.py
+++ b/modules/whisper/whisper_base.py
@@ -246,8 +246,6 @@ class WhisperBase(ABC):
             print(f"Error transcribing file: {e}")
         finally:
             self.release_cuda_memory()
-            if not files:
-                self.remove_input_files([file.name for file in files])
 
     def transcribe_mic(self,
                        mic_audio: str,
@@ -303,7 +301,6 @@ class WhisperBase(ABC):
             print(f"Error transcribing file: {e}")
         finally:
             self.release_cuda_memory()
-            self.remove_input_files([mic_audio])
 
     def transcribe_youtube(self,
                            youtube_link: str,
@@ -364,17 +361,7 @@ class WhisperBase(ABC):
         except Exception as e:
             print(f"Error transcribing file: {e}")
         finally:
-            try:
-                if 'yt' not in locals():
-                    yt = get_ytdata(youtube_link)
-                    file_path = get_ytaudio(yt)
-                else:
-                    file_path = get_ytaudio(yt)
-
-                self.release_cuda_memory()
-                self.remove_input_files([file_path])
-            except Exception as cleanup_error:
-                pass
+            self.release_cuda_memory()
 
     @staticmethod
     def generate_and_write_file(file_name: str,


### PR DESCRIPTION
## Changed
1. Since `gradio` now supports new way to clean up the cache - https://www.gradio.app/guides/resource-cleanup#automatic-cache-cleanup-via-delete-cache
Remove deprecated functions and use `gradio`'s.
