### PR TITLE
Update available models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.png
 *.mp4
 *.mp3
+.idea/
+.pytest_cache/
 venv/
 modules/ui/__pycache__/
 outputs/

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -159,7 +159,7 @@ class FasterWhisperInference(WhisperBase):
         ----------
         Name list of models
         """
-        model_paths = {model:model for model in whisper.available_models()}
+        model_paths = {model:model for model in faster_whisper.available_models()}
         faster_whisper_prefix = "models--Systran--faster-whisper-"
 
         existing_models = os.listdir(self.model_dir)


### PR DESCRIPTION
## Related issues
- https://github.com/jhj0517/Whisper-WebUI/issues/309
- https://github.com/SYSTRAN/faster-whisper/issues/1030

## Changed
1. Since `turbo` is not yet officially supported in `faster-whisper`, update `available_models()` to `faster-whisper`'s.
