### PR TITLE
Fix/cudnn problem

### DIFF
--- a/modules/whisper/insanely_fast_whisper_inference.py
+++ b/modules/whisper/insanely_fast_whisper_inference.py
@@ -78,7 +78,8 @@ class InsanelyFastWhisperInference(WhisperBase):
             kwargs = {
                 "no_speech_threshold": params.no_speech_threshold,
                 "temperature": params.temperature,
-                "compression_ratio_threshold": params.compression_ratio_threshold
+                "compression_ratio_threshold": params.compression_ratio_threshold,
+                "logprob_threshold": params.log_prob_threshold,
             }
 
             if self.current_model_size.endswith(".en"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ torch==2.3.1
 torchaudio==2.3.1
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.0.3
-transformers==4.42.3
-gradio==4.43.0
+transformers
+gradio
 pytubefix
 ruamel.yaml==0.18.6
 pyannote.audio==3.3.1;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,11 @@
 # If you're using it, update url to your CUDA version (CUDA 12.1 is minimum requirement):
 # For CUDA 12.1, use : https://download.pytorch.org/whl/cu121
 # For CUDA 12.4, use : https://download.pytorch.org/whl/cu124
---extra-index-url https://download.pytorch.org/whl/cu124
+--extra-index-url https://download.pytorch.org/whl/cu121
 
 
-torch
+torch==2.3.1
+torchaudio==2.3.1
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.0.3
 transformers==4.42.3


### PR DESCRIPTION
## Related issues / PR
- #317 
- #271
- https://github.com/OpenNMT/CTranslate2/issues/1780
- https://github.com/SYSTRAN/faster-whisper/pull/958

## Summarize Changes 
1. Since CTranslate2 does not support cuDNN 9 build and `torch >= 2.4` automatically installs its own dependent cuDNN, faster-whisper is incompatible with `torch >= 2.4`, so need to downgrade `torch`. This is a temporary fix until CTranslate2 supports cuDNN 9 build.

2. Use pypi indexing for `gradio` and `transformers` and fix `insanely_fast_whisper_inference` crash.