### PR TITLE
Remove file_types attribute

### DIFF
--- a/app.py
+++ b/app.py
@@ -291,8 +291,7 @@ class App:
 
                 with gr.TabItem("T2T Translation"):  # tab 4
                     with gr.Row():
-                        file_subs = gr.Files(type="filepath", label="Upload Subtitle Files to translate here",
-                                             file_types=['.vtt', '.srt'])
+                        file_subs = gr.Files(type="filepath", label="Upload Subtitle Files to translate here")
 
                     with gr.TabItem("DeepL API"):  # sub tab1
                         with gr.Row():


### PR DESCRIPTION
## Related issues / PRs
- #335

## Summarize Changes
1. In gradio 5 there is something different / buggy about the `file_types` attribute. So just remove it for now.
See the documentation  : https://www.gradio.app/docs/gradio/file
