### PR TITLE
Downgrade ctranslate2

### DIFF
--- a/notebook/whisper-webui.ipynb
+++ b/notebook/whisper-webui.ipynb
@@ -54,6 +54,7 @@
         "%cd Whisper-WebUI\n",
         "!pip install git+https://github.com/jhj0517/jhj0517-whisper.git\n",
         "!pip install faster-whisper==1.0.3\n",
+        "!pip install ctranslate2==4.4.0\n",
         "!pip install gradio\n",
         "!pip install git+https://github.com/jhj0517/gradio-i18n.git@fix/encoding-error\n",
         "# Temporal bug fix from https://github.com/jhj0517/Whisper-WebUI/issues/256\n",


### PR DESCRIPTION
## Related issues / PRs
- #346 
- #347

## Summarize Changes
1. Somehow colab isn't compatible with `ctranslate==4.5.0` (Regardless of `torch` version, tested with `torch >= 2.4.1`). So downgrade `ctranslate2` to 4.4.0.