### PR TITLE
Update to gradio-i18n to official package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.0.3
 transformers
 gradio
-git+https://github.com/jhj0517/gradio-i18n.git@fix/encoding-error
+git+https://github.com/jhj0517/gradio-i18n.git
 pytubefix
 ruamel.yaml==0.18.6
 pyannote.audio==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.0.3
 transformers
 gradio
-git+https://github.com/jhj0517/gradio-i18n.git
+gradio-i18n
 pytubefix
 ruamel.yaml==0.18.6
 pyannote.audio==3.3.1


### PR DESCRIPTION
## Related issues / PRs
- #356

## Summarize Changes
1. https://github.com/hoveychen/gradio-i18n/pull/2 is merged and updated so use official package.
