### PR TITLE
Enable direct use of model from huggingface

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,7 +49,7 @@ class App:
 
         with gr.Row():
             dd_model = gr.Dropdown(choices=self.whisper_inf.available_models, value=whisper_params["model_size"],
-                                   label=_("Model"))
+                                   label=_("Model"), allow_custom_value=True)
             dd_lang = gr.Dropdown(choices=self.whisper_inf.available_langs + [AUTOMATIC_DETECTION],
                                   value=AUTOMATIC_DETECTION if whisper_params["lang"] == AUTOMATIC_DETECTION.unwrap()
                                   else whisper_params["lang"], label=_("Language"))

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -135,10 +135,10 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
                   f"\"{os.path.join(self.model_dir, model_size_dirname)} ...")
             huggingface_hub.snapshot_download(
                 model_size,
-                cache_dir=self.model_dir,
-                local_dir=os.path.join(self.model_dir, model_size_dirname)
+                local_dir=os.path.join(self.model_dir, model_size_dirname),
             )
             self.model_paths = self.get_model_paths()
+            gr.Info(f"Model is downloaded with the name \"{model_size_dirname}\"")
 
         self.current_model_size = self.model_paths[model_size_dirname]
 

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -128,14 +128,18 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         """
         progress(0, desc="Initializing Model..")
 
-        if model_size not in self.model_paths:
-            huggingface_hub.snapshot_download(model_size,
-                                              cache_dir=self.model_dir,
-                                              local_dir=os.path.join(self.model_dir, model_size.replace("/", "_"))
-                                              )
+        model_size_dirname = model_size.replace("/", "--") if "/" in model_size else model_size
+        if model_size not in self.model_paths and model_size_dirname not in self.model_paths:
+            print(f"Model is not detected. Trying to download \"{model_size}\" from huggingface to "
+                  f"\"{os.path.join(self.model_dir, model_size_dirname)} ...")
+            huggingface_hub.snapshot_download(
+                model_size,
+                cache_dir=self.model_dir,
+                local_dir=os.path.join(self.model_dir, model_size_dirname)
+            )
             self.model_paths = self.get_model_paths()
 
-        self.current_model_size = self.model_paths[model_size]
+        self.current_model_size = self.model_paths[model_size_dirname]
 
         local_files_only = False
         hf_prefix = "models--Systran--faster-whisper-"

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -119,7 +119,8 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         Parameters
         ----------
         model_size: str
-            Size of whisper model
+            Size of whisper model. If you enter the huggingface repo id, it will try to download the model
+            automatically from huggingface.
         compute_type: str
             Compute type for transcription.
             see more info : https://opennmt.net/CTranslate2/quantization.html

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -131,7 +131,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         if model_size not in self.model_paths:
             huggingface_hub.snapshot_download(model_size,
                                               cache_dir=self.model_dir,
-                                              local_dir=os.path.join(self.model_dir, model_size)
+                                              local_dir=os.path.join(self.model_dir, model_size.replace("/", "_"))
                                               )
             self.model_paths = self.get_model_paths()
 

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -1,5 +1,6 @@
 import os
 import time
+import huggingface_hub
 import numpy as np
 import torch
 from typing import BinaryIO, Union, Tuple, List
@@ -126,6 +127,14 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
             Indicator to show progress directly in gradio.
         """
         progress(0, desc="Initializing Model..")
+
+        if model_size not in self.model_paths:
+            huggingface_hub.snapshot_download(model_size,
+                                              cache_dir=self.model_dir,
+                                              local_dir=os.path.join(self.model_dir, model_size)
+                                              )
+            self.model_paths = self.get_model_paths()
+
         self.current_model_size = self.model_paths[model_size]
 
         local_files_only = False


### PR DESCRIPTION
## Related issues / PRs
- #406

## Summarize Changes
1. Enable direct use of model from huggingface. 
Since the character `/` couldn't be used in the directory path, it's automatically updated to `--`. 
