### PR TITLE
Fix dockerfile installation logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install -U -r requirements.txt
 
 
 FROM debian:bookworm-slim AS runtime


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
Currently `--no-cache-dir` is being used for Docker installation. This guarantees to install the latest version of the packages if some packages are problematic, but increases the installation time excessively. 
`-U` would guarantee to use the latest version of the packages and probably does the same thing.

## Summarize Changes
1. Update from `--no-cache-dir` to `-U`
