### PR TITLE
Fix docker push with cleaning cache

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Clean up space for action
+        run: rm -rf /opt/hostedtoolcache
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- https://github.com/jhj0517/Whisper-WebUI/actions/runs/12005026101

Currently the disk is about 7GB~ when build finished. 
But it's saying that disk space is not enough, so clean the cache like other CI workflow.

## Summarize Changes
1. Clean the cache to get more space in the action
