### PR TITLE
chore: update volume paths in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,11 +4,11 @@ services:
     image: jhj0517/whisper-webui:latest
 
     volumes:
-      # Update paths to mount models and output paths to your custom paths like this, e.g:
-      # - C:/whisper-models/custom-path:/Whisper-WebUI/models
-      # - C:/whisper-webui-outputs/custom-path:/Whisper-WebUI/outputs
-      - /Whisper-WebUI/models
-      - /Whisper-WebUI/outputs
+      # You can place your models in the `./models` directory on your machine
+      # and they will be automatically available in the Docker container.
+      # Similarly, all output files will be stored in the `./outputs` directory.
+      - ./models:/Whisper-WebUI/models
+      - ./outputs:/Whisper-WebUI/outputs
 
     ports:
       - "7860:7860"


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- N/A

## Summarize Changes
1. Updated `docker-compose.yaml` to use relative paths for model and output directories:
   ```yaml
   - ./models:/Whisper-WebUI/models
   - ./outputs:/Whisper-WebUI/outputs
   ```
   Previously:
   ```yaml
   - /Whisper-WebUI/models
   - /Whisper-WebUI/outputs
   ```

## Why is this better?
1. **Simplified Model Management**:
   - Models can be managed directly from the local `models` directory.
2. **Faster Container Startup**:
   - Models are not reloaded with every container start.
3. **Improved UX**:
   - Users can easily work with `./models` and `./outputs` without additional configuration.
4. **Enhanced Flexibility**:
   - Local directories allow straightforward customization and modification of models and results.

## Impact
- Maintains backward compatibility.
- No additional dependencies or configurations are required.
- Improves efficiency, flexibility, and user satisfaction.