### PR TITLE
Install `faster-whisper` directly from repository

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 torch
 torchaudio
 git+https://github.com/jhj0517/jhj0517-whisper.git
-faster-whisper==1.0.3
+git+https://github.com/SYSTRAN/faster-whisper.git
 transformers
 gradio
 gradio-i18n


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #423 
- #421

There is currently a bug related to VAD in `faster-whisper`.

## Summarize Changes
1. Install `faster-whisper` directly from repository. 

I'm not sure if this is a wise choice, but it would at least fix the VAD bug.