### PR TITLE
Use fixed version of `faster-whisper==1.1.1`

### DIFF
--- a/modules/vad/silero_vad.py
+++ b/modules/vad/silero_vad.py
@@ -92,6 +92,7 @@ class SileroVAD:
             vad_options = VadOptions(**kwargs)
 
         threshold = vad_options.threshold
+        neg_threshold = vad_options.neg_threshold
         min_speech_duration_ms = vad_options.min_speech_duration_ms
         max_speech_duration_s = vad_options.max_speech_duration_s
         min_silence_duration_ms = vad_options.min_silence_duration_ms
@@ -117,7 +118,8 @@ class SileroVAD:
         triggered = False
         speeches = []
         current_speech = {}
-        neg_threshold = vad_options.neg_threshold
+        if neg_threshold is None:
+            neg_threshold = max(threshold - 0.15, 0.01)
 
         # to save potential segment end (and tolerate some silence)
         temp_end = 0

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -160,6 +160,8 @@ class BaseTranscriptionPipeline(ABC):
                 segments=result,
                 speech_chunks=speech_chunks,
             )
+            if not result:
+                raise ValueError("VAD detected no speech segments in the audio.")
 
         if diarization_params.is_diarize:
             result, elapsed_time_diarization = self.diarizer.run(

--- a/notebook/whisper-webui.ipynb
+++ b/notebook/whisper-webui.ipynb
@@ -53,7 +53,7 @@
         "!git clone https://github.com/jhj0517/Whisper-WebUI.git\n",
         "%cd Whisper-WebUI\n",
         "!pip install git+https://github.com/jhj0517/jhj0517-whisper.git\n",
-        "!pip install git+https://github.com/SYSTRAN/faster-whisper.git\n",
+        "!pip install faster-whisper==1.1.1\n",
         "!pip install ctranslate2==4.4.0\n",
         "!pip install gradio\n",
         "!pip install gradio-i18n\n",
@@ -129,12 +129,12 @@
         "id": "Qosz9BFlGui3",
         "cellView": "form"
       },
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "PQroYRRZzQiN",
         "cellView": "form"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 torch
 torchaudio
 git+https://github.com/jhj0517/jhj0517-whisper.git
-faster-whisper==1.1.0
+faster-whisper==1.1.1
 transformers
 gradio
 gradio-i18n

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 torch
 torchaudio
 git+https://github.com/jhj0517/jhj0517-whisper.git
-git+https://github.com/SYSTRAN/faster-whisper.git
+faster-whisper==1.1.0
 transformers
 gradio
 gradio-i18n


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #440

## Summarize Changes
1. Use fixed version of `faster-whisper==1.1.1` and fix none type error
2. Update `faster-whisper` version in the colab notebook as well
