### PR TITLE
Fix wrong input for the diarization pipeline

### DIFF
--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -261,8 +261,7 @@ class BaseTranscriptionPipeline(ABC):
             return result_str, result_file_path
 
         except Exception as e:
-            print(f"Error transcribing file: {e}")
-            raise
+            raise RuntimeError(f"Error transcribing file: {e}") from e
         finally:
             self.release_cuda_memory()
 
@@ -325,8 +324,7 @@ class BaseTranscriptionPipeline(ABC):
             result_str = f"Done in {self.format_time(time_for_task)}! Subtitle file is in the outputs folder.\n\n{subtitle}"
             return result_str, file_path
         except Exception as e:
-            print(f"Error transcribing mic: {e}")
-            raise
+            raise RuntimeError(f"Error transcribing mic: {e}") from e
         finally:
             self.release_cuda_memory()
 
@@ -398,8 +396,7 @@ class BaseTranscriptionPipeline(ABC):
             return result_str, file_path
 
         except Exception as e:
-            print(f"Error transcribing youtube: {e}")
-            raise
+            raise RuntimeError(f"Error transcribing youtube: {e}") from e
         finally:
             self.release_cuda_memory()
 

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -9,6 +9,7 @@ import numpy as np
 from datetime import datetime
 from faster_whisper.vad import VadOptions
 import gc
+from copy import deepcopy
 
 from modules.uvr.music_separator import MusicSeparator
 from modules.utils.paths import (WHISPER_MODELS_DIR, DIARIZATION_MODELS_DIR, OUTPUT_DIR, DEFAULT_PARAMETERS_CONFIG_PATH,
@@ -106,7 +107,7 @@ class BaseTranscriptionPipeline(ABC):
         params = TranscriptionPipelineParams.from_list(list(pipeline_params))
         params = self.validate_gradio_values(params)
         bgm_params, vad_params, whisper_params, diarization_params = params.bgm_separation, params.vad, params.whisper, params.diarization
-        origin_audio = audio
+        origin_audio = deepcopy(audio)
 
         if bgm_params.is_separate_bgm:
             music, audio, _ = self.music_separator.separate(

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -106,6 +106,7 @@ class BaseTranscriptionPipeline(ABC):
         params = TranscriptionPipelineParams.from_list(list(pipeline_params))
         params = self.validate_gradio_values(params)
         bgm_params, vad_params, whisper_params, diarization_params = params.bgm_separation, params.vad, params.whisper, params.diarization
+        origin_audio = audio
 
         if bgm_params.is_separate_bgm:
             music, audio, _ = self.music_separator.separate(
@@ -164,7 +165,7 @@ class BaseTranscriptionPipeline(ABC):
 
         if diarization_params.is_diarize:
             result, elapsed_time_diarization = self.diarizer.run(
-                audio=audio,
+                audio=origin_audio,
                 use_auth_token=diarization_params.hf_token,
                 transcribed_result=result,
                 device=diarization_params.diarization_device


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #456

## Summarize Changes
1. When using VAD + Diarization together, the Diarization received the wrong `audio` input, which was processed by the VAD. 
So the pass the `origin_audio` to the Diarization pipeline.

2. Refactored error rasing

