### PR TITLE
Add ability to save output as same directory with inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,7 +119,7 @@ class App:
                                                                   visible=self.args.colab,
                                                                   value=False)
                             cb_save_same_dir = gr.Checkbox(label="Save outputs at same directory",
-                                                           info="When using Input Folder Path above, whether to save output in the same directory as inputs or not, instead of original"
+                                                           info="When using Input Folder Path above, whether to save output in the same directory as inputs or not, in addition to the original"
                                                                 " output directory.",
                                                            visible=self.args.colab,
                                                            value=True)

--- a/app.py
+++ b/app.py
@@ -118,6 +118,10 @@ class App:
                                                                   info="When using Input Folder Path above, whether to include all files in the subdirectory or not",
                                                                   visible=self.args.colab,
                                                                   value=False)
+                            cb_save_same_dir = gr.Checkbox(label="Save outputs at same directory",
+                                                           info="When using Input Folder Path above, whether to save output in the same directory as inputs or not.",
+                                                           visible=self.args.colab,
+                                                           value=True)
                         pipeline_params, dd_file_format, cb_timestamp = self.create_pipeline_inputs()
 
                         with gr.Row():
@@ -127,9 +131,11 @@ class App:
                             files_subtitles = gr.Files(label=_("Downloadable output file"), scale=3, interactive=False)
                             btn_openfolder = gr.Button('📂', scale=1)
 
-                        params = [input_file, tb_input_folder, cb_include_subdirectory, dd_file_format, cb_timestamp]
+                        params = [input_file, tb_input_folder, cb_include_subdirectory, cb_save_same_dir,
+                                  dd_file_format, cb_timestamp]
+                        params = params + pipeline_params
                         btn_run.click(fn=self.whisper_inf.transcribe_file,
-                                      inputs=params + pipeline_params,
+                                      inputs=params,
                                       outputs=[tb_indicator, files_subtitles])
                         btn_openfolder.click(fn=lambda: self.open_folder("outputs"), inputs=None, outputs=None)
 

--- a/app.py
+++ b/app.py
@@ -115,11 +115,12 @@ class App:
                                                          visible=self.args.colab,
                                                          value="")
                             cb_include_subdirectory = gr.Checkbox(label="Include Subdirectory Files",
-                                                                  info="When using Input Folder Path above, whether to include all files in the subdirectory or not",
+                                                                  info="When using Input Folder Path above, whether to include all files in the subdirectory or not.",
                                                                   visible=self.args.colab,
                                                                   value=False)
                             cb_save_same_dir = gr.Checkbox(label="Save outputs at same directory",
-                                                           info="When using Input Folder Path above, whether to save output in the same directory as inputs or not.",
+                                                           info="When using Input Folder Path above, whether to save output in the same directory as inputs or not, instead of original"
+                                                                " output directory.",
                                                            visible=self.args.colab,
                                                            value=True)
                         pipeline_params, dd_file_format, cb_timestamp = self.create_pipeline_inputs()

--- a/configs/default_parameters.yaml
+++ b/configs/default_parameters.yaml
@@ -30,7 +30,7 @@ whisper:
   hotwords: null
   language_detection_threshold: 0.5
   language_detection_segments: 1
-  add_timestamp: true
+  add_timestamp: false
 
 vad:
   vad_filter: false
@@ -62,4 +62,4 @@ translation:
     source_lang: null
     target_lang: null
     max_length: 200
-  add_timestamp: true
+  add_timestamp: false

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -249,10 +249,17 @@ class BaseTranscriptionPipeline(ABC):
                 file_name, file_ext = os.path.splitext(os.path.basename(file))
                 if save_same_dir and input_folder_path:
                     output_dir = os.path.dirname(file)
-                else:
-                    output_dir = self.output_dir
+                    subtitle, file_path = generate_file(
+                        output_dir=output_dir,
+                        output_file_name=file_name,
+                        output_format=file_format,
+                        result=transcribed_segments,
+                        add_timestamp=add_timestamp,
+                        **writer_options
+                    )
+
                 subtitle, file_path = generate_file(
-                    output_dir=output_dir,
+                    output_dir=self.output_dir,
                     output_file_name=file_name,
                     output_format=file_format,
                     result=transcribed_segments,

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -185,6 +185,7 @@ class BaseTranscriptionPipeline(ABC):
                         files: Optional[List] = None,
                         input_folder_path: Optional[str] = None,
                         include_subdirectory: Optional[str] = None,
+                        save_same_dir: Optional[str] = None,
                         file_format: str = "SRT",
                         add_timestamp: bool = True,
                         progress=gr.Progress(),
@@ -201,7 +202,11 @@ class BaseTranscriptionPipeline(ABC):
             Input folder path to transcribe from gr.Textbox(). If this is provided, `files` will be ignored and
             this will be used instead.
         include_subdirectory: Optional[str]
-            When using Input Folder Path above, whether to include all files in the subdirectory or not
+            When using `input_folder_path`, whether to include all files in the subdirectory or not
+        save_same_dir: Optional[str]
+            When using `input_folder_path`, whether to save output in the same directory as input or not.
+            This feature is only available when using `input_folder_path`, because gradio only allows to use
+            cached file path in the function yet.
         file_format: str
             Subtitle File format to write from gr.Dropdown(). Supported format: [SRT, WebVTT, txt]
         add_timestamp: bool

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -247,8 +247,12 @@ class BaseTranscriptionPipeline(ABC):
                 )
 
                 file_name, file_ext = os.path.splitext(os.path.basename(file))
+                if save_same_dir and input_folder_path:
+                    output_dir = os.path.dirname(file)
+                else:
+                    output_dir = self.output_dir
                 subtitle, file_path = generate_file(
-                    output_dir=self.output_dir,
+                    output_dir=output_dir,
                     output_file_name=file_name,
                     output_format=file_format,
                     result=transcribed_segments,

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -204,9 +204,9 @@ class BaseTranscriptionPipeline(ABC):
         include_subdirectory: Optional[str]
             When using `input_folder_path`, whether to include all files in the subdirectory or not
         save_same_dir: Optional[str]
-            When using `input_folder_path`, whether to save output in the same directory as inputs or not.
-            This feature is only available when using `input_folder_path`, because gradio only allows to use
-            cached file path in the function yet.
+            When using `input_folder_path`, whether to save output in the same directory as inputs or not, in addition
+            to the original output directory. This feature is only available when using `input_folder_path`, because
+            gradio only allows to use cached file path in the function yet.
         file_format: str
             Subtitle File format to write from gr.Dropdown(). Supported format: [SRT, WebVTT, txt]
         add_timestamp: bool

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -204,7 +204,7 @@ class BaseTranscriptionPipeline(ABC):
         include_subdirectory: Optional[str]
             When using `input_folder_path`, whether to include all files in the subdirectory or not
         save_same_dir: Optional[str]
-            When using `input_folder_path`, whether to save output in the same directory as input or not.
+            When using `input_folder_path`, whether to save output in the same directory as inputs or not.
             This feature is only available when using `input_folder_path`, because gradio only allows to use
             cached file path in the function yet.
         file_format: str

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -60,6 +60,7 @@ def test_transcribe(
         [audio_path],
         None,
         None,
+        None,
         "SRT",
         False,
         gr.Progress(),


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #466

## Summarize Changes
1. Add ability to save outputs to the same directory as input file paths. If `save_same_dir` is True, it generates to both file paths to [/outputs](https://github.com/jhj0517/Whisper-WebUI/tree/master/outputs) and the same directory with inputs.
2. Set `add_timestamp` to false by default
