### PR TITLE
Fix total time elapsed does not account for all steps

### DIFF
--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from faster_whisper.vad import VadOptions
 import gc
 from copy import deepcopy
-
 import time
 
 from modules.uvr.music_separator import MusicSeparator


### PR DESCRIPTION
## Summarize Changes
1. Fix total time elapsed does not account for all steps like UVR, copying original audio for speaker diarization, VAD,  restoring the timestamps after VAD
2. add some more progress messages to give the user a bit more information
