### PR TITLE
add option to provide HuggingFace-token via environment variable

### DIFF
--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -179,7 +179,7 @@ class BaseTranscriptionPipeline(ABC):
         if diarization_params.is_diarize:
             result, elapsed_time_diarization = self.diarizer.run(
                 audio=origin_audio,
-                use_auth_token=diarization_params.hf_token,
+                use_auth_token=diarization_params.hf_token if diarization_params.hf_token else os.environ.get("HF_TOKEN"),
                 transcribed_result=result,
                 device=diarization_params.diarization_device
             )


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- when running Whisper-WebUI from docker, the cache folder for the huggingface diarization moddel is not a persistent folder. That means with every restart of the docker container, the hugging face token needs to be provided again via Gradio Webinterface so that the speaker diarization model can be downloaded again.

## Summarize Changes
1. if the hugging face token is empty, then try to grab it from the environment variable "HF_TOKEN"

With this change it is possible to provide the HF token via environment variable to the docker container and does not have to be entered every time the docker container is restarted