### PR TITLE
Validate segments

### DIFF
--- a/modules/utils/subtitle_manager.py
+++ b/modules/utils/subtitle_manager.py
@@ -134,6 +134,12 @@ class SubtitlesWriter(ResultWriter):
         align_lrc_words: bool = False,
         max_words_per_line: Optional[int] = None,
     ):
+        if not isinstance(result, dict):
+            return
+        if "segments" not in result or not isinstance(result["segments"], list):
+            return
+        if len(result["segments"]) == 0:
+            return
         options = options or {}
         max_line_width = max_line_width or options.get("max_line_width")
         max_line_count = max_line_count or options.get("max_line_count")

--- a/modules/utils/subtitle_manager.py
+++ b/modules/utils/subtitle_manager.py
@@ -134,12 +134,6 @@ class SubtitlesWriter(ResultWriter):
         align_lrc_words: bool = False,
         max_words_per_line: Optional[int] = None,
     ):
-        if not isinstance(result, dict):
-            return
-        if "segments" not in result or not isinstance(result["segments"], list):
-            return
-        if len(result["segments"]) == 0:
-            return
         options = options or {}
         max_line_width = max_line_width or options.get("max_line_width")
         max_line_count = max_line_count or options.get("max_line_count")

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -196,6 +196,10 @@ class BaseTranscriptionPipeline(ABC):
             add_timestamp=add_timestamp
         )
 
+        if not result:
+            logger.info(f"Whisper did not detected any speech segments in the audio.")
+            result = [Segment()]
+
         progress(1.0, desc="Finished.")
         total_elapsed_time = time.time() - start_time
         return result, total_elapsed_time


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #
Validate segments not empty in subtitle_manager.py
## Summarize Changes
1. 
Perform defensive checking to avoid the "list indices must be integers or slices, not str" exception caused by null values.
test file: https://github.com/anars/blank-audio/blob/master/10-minutes-of-silence.mp3