### PR TITLE
Upgrade `ctranslate2` version in colab

### DIFF
--- a/notebook/whisper-webui.ipynb
+++ b/notebook/whisper-webui.ipynb
@@ -54,7 +54,6 @@
         "%cd Whisper-WebUI\n",
         "!pip install git+https://github.com/jhj0517/jhj0517-whisper.git\n",
         "!pip install faster-whisper==1.1.1\n",
-        "!pip install ctranslate2==4.4.0\n",
         "!pip install gradio\n",
         "!pip install gradio-i18n\n",
         "# Temporal bug fix from https://github.com/jhj0517/Whisper-WebUI/issues/256\n",
@@ -138,7 +137,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "PQroYRRZzQiN",
         "cellView": "form"


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #489 ( Colab notebook broken for `faster-whisper` )

## Summarize Changes
1. Colab now uses CUDA 12.5 by default. So upgrade to `ctranlsate2==4.5.0` which is compatible.
