### PR TITLE
Add progress number tracking for `/transcription` endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -59,6 +59,7 @@ You can set some server configurations in [config.yaml](https://github.com/jhj05
 <br>If the endpoint generates and saves the file, all output files are stored in the `cache` directory, e.g. separated vocal/instrument files for `/bgm-separation` are saved in `cache` directory.
 
 ## Docker
+You can also deploy the server with Docker for easy deployment.
 The Dockerfile should be built when you're in the root directory of Whisper-WebUI.
 
 1. git clone this repository

--- a/backend/configs/.env.example
+++ b/backend/configs/.env.example
@@ -1,0 +1,2 @@
+HF_TOKEN="YOUR_HF_TOKEN FOR DIARIZATION MODEL (READ PERMISSION)"
+DB_URL="sqlite:///backend/records.db"

--- a/backend/db/task/models.py
+++ b/backend/db/task/models.py
@@ -174,7 +174,8 @@ class Task(SQLModel, table=True):
             result=self.result,
             task_params=self.task_params,
             error=self.error,
-            duration=self.duration
+            duration=self.duration,
+            progress=self.progress
         )
 
 

--- a/backend/db/task/models.py
+++ b/backend/db/task/models.py
@@ -66,6 +66,10 @@ class TaskStatusResponse(BaseModel):
         default=None,
         description="Duration of the task execution"
     )
+    progress: Optional[float] = Field(
+        default=0.0,
+        description="Progress of the task"
+    )
 
 
 class Task(SQLModel, table=True):
@@ -84,6 +88,7 @@ class Task(SQLModel, table=True):
     - error: Error message, if any, associated with the task.
     - created_at: Date and time of creation.
     - updated_at: Date and time of last update.
+    - progress: Progress of the task. If it is None, it means the progress tracking for the task is not started yet.
     """
 
     __tablename__ = "tasks"
@@ -154,6 +159,10 @@ class Task(SQLModel, table=True):
         default_factory=datetime.utcnow,
         sa_column_kwargs={"onupdate": datetime.utcnow},
         description="Date and time of last update"
+    )
+    progress: Optional[float] = Field(
+        default=0.0,
+        description="Progress of the task"
     )
 
     def to_response(self) -> "TaskStatusResponse":

--- a/backend/routers/transcription/router.py
+++ b/backend/routers/transcription/router.py
@@ -85,7 +85,8 @@ def run_transcription(
             "status": TaskStatus.COMPLETED,
             "result": segments,
             "updated_at": datetime.utcnow(),
-            "duration": elapsed_time
+            "duration": elapsed_time,
+            "progress": 1.0,
         },
     )
     return segments

--- a/backend/routers/transcription/router.py
+++ b/backend/routers/transcription/router.py
@@ -33,7 +33,7 @@ def create_progress_callback(identifier: str):
             update_data={
                 "uuid": identifier,
                 "status": TaskStatus.IN_PROGRESS,
-                "progress": progress_value,
+                "progress": round(progress_value, 2),
                 "updated_at": datetime.utcnow()
             },
         )

--- a/backend/routers/transcription/router.py
+++ b/backend/routers/transcription/router.py
@@ -26,6 +26,20 @@ from backend.db.task.models import TaskStatus, TaskType
 transcription_router = APIRouter(prefix="/transcription", tags=["Transcription"])
 
 
+def create_progress_callback(identifier: str):
+    def progress_callback(progress_value: float):
+        update_task_status_in_db(
+            identifier=identifier,
+            update_data={
+                "uuid": identifier,
+                "status": TaskStatus.IN_PROGRESS,
+                "progress": progress_value,
+                "updated_at": datetime.utcnow()
+            },
+        )
+    return progress_callback
+
+
 @functools.lru_cache
 def get_pipeline() -> 'FasterWhisperInference':
     config = load_server_config()["whisper"]
@@ -53,11 +67,13 @@ def run_transcription(
         },
     )
 
+    progress_callback = create_progress_callback(identifier)
     segments, elapsed_time = get_pipeline().run(
         audio,
         gr.Progress(),
         "SRT",
         False,
+        progress_callback,  
         *params.to_list()
     )
     segments = [seg.model_dump() for seg in segments]

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -275,6 +275,7 @@ class BaseTranscriptionPipeline(ABC):
                     progress,
                     file_format,
                     add_timestamp,
+                    None,
                     *pipeline_params,
                 )
 
@@ -360,6 +361,7 @@ class BaseTranscriptionPipeline(ABC):
                 progress,
                 file_format,
                 add_timestamp,
+                None,
                 *pipeline_params,
             )
             progress(1, desc="Completed!")
@@ -426,6 +428,7 @@ class BaseTranscriptionPipeline(ABC):
                 progress,
                 file_format,
                 add_timestamp,
+                None,
                 *pipeline_params,
             )
 

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -172,6 +172,7 @@ class BaseTranscriptionPipeline(ABC):
         result, elapsed_time_transcription = self.transcribe(
             audio,
             progress,
+            progress_callback,
             *whisper_params.to_list()
         )
         if whisper_params.enable_offload:

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -4,7 +4,7 @@ import ctranslate2
 import gradio as gr
 import torchaudio
 from abc import ABC, abstractmethod
-from typing import BinaryIO, Union, Tuple, List
+from typing import BinaryIO, Union, Tuple, List, Callable
 import numpy as np
 from datetime import datetime
 from faster_whisper.vad import VadOptions
@@ -80,6 +80,7 @@ class BaseTranscriptionPipeline(ABC):
             progress: gr.Progress = gr.Progress(),
             file_format: str = "SRT",
             add_timestamp: bool = True,
+            progress_callback: Optional[Callable] = None,
             *pipeline_params,
             ) -> Tuple[List[Segment], float]:
         """
@@ -98,6 +99,9 @@ class BaseTranscriptionPipeline(ABC):
             Subtitle file format between ["SRT", "WebVTT", "txt", "lrc"]
         add_timestamp: bool
             Whether to add a timestamp at the end of the filename.
+        progress_callback: Optional[Callable]
+            callback function to show progress. Can be used to update progress in the backend.
+
         *pipeline_params: tuple
             Parameters for the transcription pipeline. This will be dealt with "TranscriptionPipelineParams" data class.
             This must be provided as a List with * wildcard because of the integration with gradio.

--- a/modules/whisper/base_transcription_pipeline.py
+++ b/modules/whisper/base_transcription_pipeline.py
@@ -61,6 +61,7 @@ class BaseTranscriptionPipeline(ABC):
     def transcribe(self,
                    audio: Union[str, BinaryIO, np.ndarray],
                    progress: gr.Progress = gr.Progress(),
+                   progress_callback: Optional[Callable] = None,
                    *whisper_params,
                    ):
         """Inference whisper model to transcribe"""

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -107,7 +107,8 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         for segment in segments:
             progress_n = segment.start / info.duration
             progress(progress_n, desc="Transcribing..")
-            progress_callback(progress_n)
+            if progress_callback is not None:
+                progress_callback(progress_n)
             segments_result.append(Segment.from_faster_whisper(segment))
 
         elapsed_time = time.time() - start_time

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -107,6 +107,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
         for segment in segments:
             progress_n = segment.start / info.duration
             progress(progress_n, desc="Transcribing..")
+            progress_callback(progress_n)
             segments_result.append(Segment.from_faster_whisper(segment))
 
         elapsed_time = time.time() - start_time

--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -3,7 +3,7 @@ import time
 import huggingface_hub
 import numpy as np
 import torch
-from typing import BinaryIO, Union, Tuple, List
+from typing import BinaryIO, Union, Tuple, List, Callable
 import faster_whisper
 from faster_whisper.vad import VadOptions
 import ast
@@ -40,6 +40,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
     def transcribe(self,
                    audio: Union[str, BinaryIO, np.ndarray],
                    progress: gr.Progress = gr.Progress(),
+                   progress_callback: Optional[Callable] = None,
                    *whisper_params,
                    ) -> Tuple[List[Segment], float]:
         """
@@ -51,6 +52,8 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
             Audio path or file binary or Audio numpy array
         progress: gr.Progress
             Indicator to show progress directly in gradio.
+        progress_callback: Optional[Callable]
+            callback function to show progress. Can be used to update progress in the backend.
         *whisper_params: tuple
             Parameters related with whisper. This will be dealt with "WhisperParameters" data class
 
@@ -102,7 +105,8 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
 
         segments_result = []
         for segment in segments:
-            progress(segment.start / info.duration, desc="Transcribing..")
+            progress_n = segment.start / info.duration
+            progress(progress_n, desc="Transcribing..")
             segments_result.append(Segment.from_faster_whisper(segment))
 
         elapsed_time = time.time() - start_time

--- a/modules/whisper/insanely_fast_whisper_inference.py
+++ b/modules/whisper/insanely_fast_whisper_inference.py
@@ -1,7 +1,7 @@
 import os
 import time
 import numpy as np
-from typing import BinaryIO, Union, Tuple, List
+from typing import BinaryIO, Union, Tuple, List, Callable
 import torch
 from transformers import pipeline
 from transformers.utils import is_flash_attn_2_available
@@ -37,6 +37,7 @@ class InsanelyFastWhisperInference(BaseTranscriptionPipeline):
     def transcribe(self,
                    audio: Union[str, np.ndarray, torch.Tensor],
                    progress: gr.Progress = gr.Progress(),
+                   progress_callback: Optional[Callable] = None,
                    *whisper_params,
                    ) -> Tuple[List[Segment], float]:
         """
@@ -48,6 +49,8 @@ class InsanelyFastWhisperInference(BaseTranscriptionPipeline):
             Audio path or file binary or Audio numpy array
         progress: gr.Progress
             Indicator to show progress directly in gradio.
+        progress_callback: Optional[Callable]
+            callback function to show progress. Can be used to update progress in the backend.
         *whisper_params: tuple
             Parameters related with whisper. This will be dealt with "WhisperParameters" data class
 

--- a/modules/whisper/whisper_Inference.py
+++ b/modules/whisper/whisper_Inference.py
@@ -1,7 +1,7 @@
 import whisper
 import gradio as gr
 import time
-from typing import BinaryIO, Union, Tuple, List
+from typing import BinaryIO, Union, Tuple, List, Callable, Optional
 import numpy as np
 import torch
 import os
@@ -29,6 +29,7 @@ class WhisperInference(BaseTranscriptionPipeline):
     def transcribe(self,
                    audio: Union[str, np.ndarray, torch.Tensor],
                    progress: gr.Progress = gr.Progress(),
+                   progress_callback: Optional[Callable] = None,
                    *whisper_params,
                    ) -> Tuple[List[Segment], float]:
         """
@@ -40,6 +41,8 @@ class WhisperInference(BaseTranscriptionPipeline):
             Audio path or file binary or Audio numpy array
         progress: gr.Progress
             Indicator to show progress directly in gradio.
+        progress_callback: Optional[Callable]
+            callback function to show progress. Can be used to update progress in the backend.
         *whisper_params: tuple
             Parameters related with whisper. This will be dealt with "WhisperParameters" data class
 


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #506

## Summarize Changes
1. Added progress callback in the transcription pipeline so users can track progress as numer in the backend
2. Added `.env.example`
3. **`progress: float` has been added to the table, the previous DB must be migrated.**
