### PR TITLE
Fix shared test module importing 

### DIFF
--- a/tests/test_bgm_separation.py
+++ b/tests/test_bgm_separation.py
@@ -1,13 +1,13 @@
-from modules.utils.paths import *
-from modules.whisper.whisper_factory import WhisperFactory
-from modules.whisper.data_classes import *
-from test_config import *
-from test_transcription import download_file, test_transcribe
-
 import gradio as gr
 import pytest
 import torch
 import os
+
+from modules.utils.paths import *
+from modules.whisper.whisper_factory import WhisperFactory
+from modules.whisper.data_classes import *
+from test_config import *
+from test_transcription import download_file, run_asr_pipeline
 
 
 @pytest.mark.skipif(
@@ -28,7 +28,7 @@ def test_bgm_separation_pipeline(
     bgm_separation: bool,
     diarization: bool,
 ):
-    test_transcribe(whisper_type, vad_filter, bgm_separation, diarization)
+    run_asr_pipeline(whisper_type, vad_filter, bgm_separation, diarization)
 
 
 @pytest.mark.skipif(
@@ -49,5 +49,5 @@ def test_bgm_separation_with_vad_pipeline(
     bgm_separation: bool,
     diarization: bool,
 ):
-    test_transcribe(whisper_type, vad_filter, bgm_separation, diarization)
+    run_asr_pipeline(whisper_type, vad_filter, bgm_separation, diarization)
 

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -1,12 +1,12 @@
+import gradio as gr
+import pytest
+import os
+
 from modules.utils.paths import *
 from modules.whisper.whisper_factory import WhisperFactory
 from modules.whisper.data_classes import *
 from test_config import *
-from test_transcription import download_file, test_transcribe
-
-import gradio as gr
-import pytest
-import os
+from test_transcription import download_file, run_asr_pipeline
 
 
 @pytest.mark.skipif(
@@ -27,5 +27,5 @@ def test_diarization_pipeline(
     bgm_separation: bool,
     diarization: bool,
 ):
-    test_transcribe(whisper_type, vad_filter, bgm_separation, diarization)
+    run_asr_pipeline(whisper_type, vad_filter, bgm_separation, diarization)
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,24 +1,16 @@
+import requests
+import pytest
+import gradio as gr
+import os
+
 from modules.whisper.whisper_factory import WhisperFactory
 from modules.whisper.data_classes import *
 from modules.utils.subtitle_manager import read_file
 from modules.utils.paths import WEBUI_DIR
 from test_config import *
 
-import requests
-import pytest
-import gradio as gr
-import os
 
-
-@pytest.mark.parametrize(
-    "whisper_type,vad_filter,bgm_separation,diarization",
-    [
-        (WhisperImpl.WHISPER.value, False, False, False),
-        (WhisperImpl.FASTER_WHISPER.value, False, False, False),
-        (WhisperImpl.INSANELY_FAST_WHISPER.value, False, False, False)
-    ]
-)
-def test_transcribe(
+def run_asr_pipeline(
     whisper_type: str,
     vad_filter: bool,
     bgm_separation: bool,
@@ -90,5 +82,22 @@ def test_transcribe(
     subtitle = read_file(file_path).split("\n")
     wer = calculate_wer(answer, subtitle[2].strip().replace(",", "").replace(".", ""))
     assert wer < 0.1, f"WER is too high, it's {wer}"
+
+
+@pytest.mark.parametrize(
+    "whisper_type,vad_filter,bgm_separation,diarization",
+    [
+        (WhisperImpl.WHISPER.value, False, False, False),
+        (WhisperImpl.FASTER_WHISPER.value, False, False, False),
+        (WhisperImpl.INSANELY_FAST_WHISPER.value, False, False, False)
+    ]
+)
+def test_transcribe(
+    whisper_type: str,
+    vad_filter: bool,
+    bgm_separation: bool,
+    diarization: bool,
+):
+    run_asr_pipeline(whisper_type, vad_filter, bgm_separation, diarization)
 
 

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -5,7 +5,7 @@ import os
 from modules.whisper.data_classes import *
 from modules.vad.silero_vad import SileroVAD
 from test_config import *
-from test_transcription import download_file, test_transcribe
+from test_transcription import download_file, run_asr_pipeline
 from faster_whisper.vad import VadOptions, get_speech_timestamps
 
 
@@ -23,7 +23,7 @@ def test_vad_pipeline(
     bgm_separation: bool,
     diarization: bool,
 ):
-    test_transcribe(whisper_type, vad_filter, bgm_separation, diarization)
+    run_asr_pipeline(whisper_type, vad_filter, bgm_separation, diarization)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
The test scripts currently import a test function from the `test_transcription` module.
**Simply importing this function unintentionally triggers the execution of `test_transcription`.**

So modularize the re-usable test function as `run_asr_pipeline()` without `@pytest` mark so let it re-usable without triggering the start of test in `test_transcription`

## Summarize Changes
1. Modularized the shared test logic into `run_asr_pipeline()`, removing the `@pytest` decorator to prevent unintended execution during import.
