### PR TITLE
Add write permission for `GITHUB_TOKEN` in the action

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
 
     strategy:
       matrix:


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #529
>[!NOTE]
> When using `GITHUB_TOKEN`, you need to explicitly write the correct permission for it. In this case `packages: write`

Doc link : https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

## Summarize Changes
1. Add `packages: write` permission in the workflow
 