### PR TITLE
Handle error when importing `uvr`

### DIFF
--- a/modules/uvr/music_separator.py
+++ b/modules/uvr/music_separator.py
@@ -8,10 +8,20 @@ import gc
 import gradio as gr
 from datetime import datetime
 
-from uvr.models import MDX, Demucs, VrNetwork, MDXC
 from modules.utils.paths import DEFAULT_PARAMETERS_CONFIG_PATH, UVR_MODELS_DIR, UVR_OUTPUT_DIR
 from modules.utils.files_manager import load_yaml, save_yaml, is_video
 from modules.diarize.audio_loader import load_audio
+from modules.utils.logger import get_logger
+logger = get_logger()
+
+try:
+    from uvr.models import MDX, Demucs, VrNetwork, MDXC
+except Exception as e:
+    logger.warning(
+        "Failed to import uvr. BGM separation feature will not work. "
+        "Please open an issue on GitHub if you encounter this error. "
+        f"Error: {e}"
+    )
 
 
 class MusicSeparator:

--- a/modules/uvr/music_separator.py
+++ b/modules/uvr/music_separator.py
@@ -21,7 +21,7 @@ except Exception as e:
     logger.warning(
         "Failed to import uvr. BGM separation feature will not work. "
         "Please open an issue on GitHub if you encounter this error. "
-        f"Error: {traceback.format_exc()}"
+        f"Error: {type(e).__name__}: {traceback.format_exc()}"
     )
 
 

--- a/modules/uvr/music_separator.py
+++ b/modules/uvr/music_separator.py
@@ -7,6 +7,7 @@ import torch
 import gc
 import gradio as gr
 from datetime import datetime
+import traceback
 
 from modules.utils.paths import DEFAULT_PARAMETERS_CONFIG_PATH, UVR_MODELS_DIR, UVR_OUTPUT_DIR
 from modules.utils.files_manager import load_yaml, save_yaml, is_video
@@ -20,7 +21,7 @@ except Exception as e:
     logger.warning(
         "Failed to import uvr. BGM separation feature will not work. "
         "Please open an issue on GitHub if you encounter this error. "
-        f"Error: {e}"
+        f"Error: {traceback.format_exc()}"
     )
 
 


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #532

## Summarize Changes
1. Handle when importing `uvr` package.

Note that the Windows 11 & `uvr` incompatibility needs to be investigated.
But it would take some time due to the limitations of my current setup.