### PR TITLE
Downgrade gradio-i18n to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
 transformers==4.47.1
 gradio
-gradio-i18n
+gradio-i18n==0.3.0
 pytubefix
 ruamel.yaml==0.18.6
 pyannote.audio==3.3.2


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #546

## Summarize Changes
1. Recent changes from `gradio-i18n` caused encoding errors when opening yaml. Not sure why.
Downgrading `gradio-i18n` fixes the bug.