### PR TITLE
Upgrade minimum CUDA version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If needed, update the [`docker-compose.yaml`](https://github.com/jhj0517/Whisper
 To run this WebUI, you need to have `git`, `3.10 <= python <= 3.12`, `FFmpeg`.
 
 **Edit `--extra-index-url` in the [`requirements.txt`](https://github.com/jhj0517/Whisper-WebUI/blob/master/requirements.txt) to match your device.<br>** 
-By default, the WebUI assumes you're using an Nvidia GPU and CUDA 12.4. If you're using Intel or another CUDA version, read the [`requirements.txt`](https://github.com/jhj0517/Whisper-WebUI/blob/master/requirements.txt) and edit `--extra-index-url`.
+By default, the WebUI assumes you're using an Nvidia GPU and **CUDA 12.6.** If you're using Intel or another CUDA version, read the [`requirements.txt`](https://github.com/jhj0517/Whisper-WebUI/blob/master/requirements.txt) and edit `--extra-index-url`.
 
 Please follow the links below to install the necessary software:
 - git : [https://git-scm.com/downloads](https://git-scm.com/downloads)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
---extra-index-url https://download.pytorch.org/whl/cu124
+--extra-index-url https://download.pytorch.org/whl/cu126
 
 # Update above --extra-index-url according to your device.
 
 ## Nvidia GPU
-# CUDA 12.1 : https://download.pytorch.org/whl/cu121
-# CUDA 12.4 : https://download.pytorch.org/whl/cu124
+# CUDA 12.6 : https://download.pytorch.org/whl/cu126
+# CUDA 12.8 : https://download.pytorch.org/whl/cu128
 
 ## Intel GPU
 # https://download.pytorch.org/whl/xpu


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- https://github.com/jhj0517/Whisper-WebUI/issues/540#issuecomment-2852001024

`torch` does not support CUDA 12.4 binaries anymore. See:
https://pytorch.org/get-started/locally/

## Summarize Changes
1. Upgrade minimum CUDA versions
