### PR TITLE
condition_on_previous_text fix

### DIFF
--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -85,6 +85,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
             compression_ratio_threshold=params.compression_ratio_threshold,
             length_penalty=params.length_penalty,
             repetition_penalty=params.repetition_penalty,
+            condition_on_previous_text=params.condition_on_previous_text,
             no_repeat_ngram_size=params.no_repeat_ngram_size,
             prefix=params.prefix,
             suppress_blank=params.suppress_blank,

--- a/modules/whisper/whisper_Inference.py
+++ b/modules/whisper/whisper_Inference.py
@@ -74,6 +74,7 @@ class WhisperInference(BaseTranscriptionPipeline):
                                        patience=params.patience,
                                        temperature=params.temperature,
                                        compression_ratio_threshold=params.compression_ratio_threshold,
+                                       condition_on_previous_text=params.condition_on_previous_text,
                                        progress_callback=progress_callback,)["segments"]
         segments_result = []
         for segment in result:


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- https://github.com/jhj0517/Whisper-WebUI/issues/570

## Summarize Changes
1. actually pass the value from the condition_on_previous_text on to the transcribe calls in whisper_inference.py and faster_whisper_inference.py
