### PR TITLE
Set `word_timestamps` to always True

### DIFF
--- a/modules/whisper/faster_whisper_inference.py
+++ b/modules/whisper/faster_whisper_inference.py
@@ -90,7 +90,7 @@ class FasterWhisperInference(BaseTranscriptionPipeline):
             suppress_blank=params.suppress_blank,
             suppress_tokens=params.suppress_tokens,
             max_initial_timestamp=params.max_initial_timestamp,
-            word_timestamps=params.word_timestamps,
+            word_timestamps=True,  # Set it to always True as it reduces hallucinations
             prepend_punctuations=params.prepend_punctuations,
             append_punctuations=params.append_punctuations,
             max_new_tokens=params.max_new_tokens,


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
I've confirmed that enabling `word_timestamps` reduces hallucinations.

## Summarize Changes
1. Set `word_timestamps` to True as it reduces hallucinations. However, word 'highlighting' in the subtitle only works when the "Word Timestamps" checkbox is enabled in the Web UI.

Even when I don't need the word highlighting feature in subtitles, I've confirmed that it reduces hallucinations, so it's now always set to True.
