### PR TITLE
fix: lock down torchaudio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 
 
 torch
-torchaudio
+torchaudio>=2.8.0,<2.9.0
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
 transformers==4.47.1


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #602
- https://github.com/m-bain/whisperX/issues/1264

## Summarize Changes
1. Lock down `torchaudio` version for incompatibility
