### PR TITLE
Add matplotlib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 ## Intel GPU
 # https://download.pytorch.org/whl/xpu
 
-
+matplotlib
 torch
 torchaudio>=2.8.0,<2.9.0
 git+https://github.com/jhj0517/jhj0517-whisper.git


### PR DESCRIPTION
Without this, I received this error on running whisper:

`RuntimeError: Error transcribing file: No module named 'matplotlib'`

After adding this line and re-building the docker, it seems to work

## Related issues / PRs. Summarize issues.
- #

## Summarize Changes
1. Add matplotlib to requirements.txt
