### PR TITLE
Limiting torch version <2.9.0 aligning with torchaudio to avoid deprecation problems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@
 # https://download.pytorch.org/whl/xpu
 
 matplotlib
-torch
-torchaudio>=2.8.0,<2.9.0
+torch>=2.8.0,<2.9.0 # Needs to be harmonized with torchaudio
+torchaudio>=2.8.0,<2.9.0 # 2.9 deprecates used functions
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
 transformers==4.47.1


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- Fixes #613

## Summarize Changes
1. Aligned torch pip package version to align with torchaudio.
    Without this, the version rule <2.9.0 is not effective during resolution, causing incompatibilities

Details on incompatibilities can be checked in the original issue, and further details can be checked on the package notes:
https://pypi.org/project/torchaudio/