### PR TITLE
Adapt python build for setuptools deprecating pkg_resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git ffmpeg
 
       - name: Install dependencies
-        run: pip install -r requirements.txt pytest jiwer
+        run: pip install wheel && pip install --no-build-isolation -r requirements.txt pytest jiwer
 
       - name: Run test
         run: python -m pytest -rs tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY requirements.txt .
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \
-    pip install -U -r requirements.txt
+    pip install wheel && \
+    pip install --no-build-isolation --no-cache-dir -U -r requirements.txt
 
 
 FROM debian:bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \
-    pip install wheel && \
+    pip install --no-cache-dir -U wheel && \
     pip install --no-build-isolation --no-cache-dir -U -r requirements.txt
 
 

--- a/Install.sh
+++ b/Install.sh
@@ -7,8 +7,8 @@ fi
 
 source venv/bin/activate
 
-python -m pip install -U pip
-pip install -r requirements.txt && echo "Requirements installed successfully." || {
+python -m pip install -U pip wheel
+pip install --no-build-isolation -r requirements.txt && echo "Requirements installed successfully." || {
     echo ""
     echo "Requirements installation failed. Please remove the venv folder and run the script again."
     deactivate

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 matplotlib
 torch>=2.8.0,<2.9.0 # Needs to be harmonized with torchaudio
 torchaudio>=2.8.0,<2.9.0 # 2.9 deprecates used functions
-setuptools==81.0.0
+setuptools==81.0.0 # Pinned to work around pkg_resources deprecation
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
 transformers==4.47.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@
 matplotlib
 torch>=2.8.0,<2.9.0 # Needs to be harmonized with torchaudio
 torchaudio>=2.8.0,<2.9.0 # 2.9 deprecates used functions
+setuptools==81.0.0
 git+https://github.com/jhj0517/jhj0517-whisper.git
 faster-whisper==1.1.1
 transformers==4.47.1


### PR DESCRIPTION
## Related issues / PRs. Summarize issues.
- #628

## Summarize Changes
1. added --no-build-isolation to pip install in the builder Docker image
2. installed wheel pip package before installing other dependencies
3. pinned setuptools version before the deprecation or required functionalities

As I understand, this is a workaround. For a proper fix, this migration guide seems the most relevant:
https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename

However, I do not really comprehend in which package these adaptations are needed.