### PR TITLE
fix: ensure float32 output in load_audio to prevent dtype mismatch (closes #634)

### DIFF
--- a/modules/diarize/audio_loader.py
+++ b/modules/diarize/audio_loader.py
@@ -81,7 +81,8 @@ def load_audio(file: Union[str, np.ndarray], sr: int = SAMPLE_RATE) -> np.ndarra
         if isinstance(file, np.ndarray):
             os.remove(temp_file_path)
 
-    return np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+    audio = np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+    return audio.astype(np.float32)
 
 
 


### PR DESCRIPTION
## What
Some external callers (e.g., ultimatevocalremover_api) may pass audio data as float64, causing a RuntimeError during resampling in torchaudio when it expects float32.

## Fix
Added an explicit .astype(np.float32) after computing the audio array in load_audio() to guarantee the returned array is always float32, even if intermediate steps produce a different dtype.

Closes #634