### PR TITLE
fix: constrain setuptools so the image builds again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git ffmpeg
 
       - name: Install dependencies
+        env:
+          PIP_CONSTRAINT: constraints.txt
+          PIP_BUILD_CONSTRAINT: constraints.txt
         run: pip install -r requirements.txt pytest jiwer
 
       - name: Run test
@@ -65,6 +68,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y git ffmpeg
 
       - name: Install dependencies
+        env:
+          PIP_CONSTRAINT: constraints.txt
+          PIP_BUILD_CONSTRAINT: constraints.txt
         run: pip install -r backend/requirements-backend.txt pytest pytest-asyncio jiwer
 
       - name: Run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ RUN apt-get update && \
 
 WORKDIR /Whisper-WebUI
 
-COPY requirements.txt .
+COPY requirements.txt constraints.txt ./
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \
-    pip install -U -r requirements.txt
+    PIP_CONSTRAINT=constraints.txt PIP_BUILD_CONSTRAINT=constraints.txt pip install -U -r requirements.txt
 
 
 FROM debian:bookworm-slim AS runtime

--- a/Install.bat
+++ b/Install.bat
@@ -9,6 +9,8 @@ echo checked the venv folder. now installing requirements..
 call "%~dp0\venv\scripts\activate"
 
 python -m pip install -U pip
+set PIP_CONSTRAINT=constraints.txt
+set PIP_BUILD_CONSTRAINT=constraints.txt
 pip install -r requirements.txt
 
 if errorlevel 1 (

--- a/Install.sh
+++ b/Install.sh
@@ -8,7 +8,7 @@ fi
 source venv/bin/activate
 
 python -m pip install -U pip
-pip install -r requirements.txt && echo "Requirements installed successfully." || {
+PIP_CONSTRAINT=constraints.txt PIP_BUILD_CONSTRAINT=constraints.txt pip install -r requirements.txt && echo "Requirements installed successfully." || {
     echo ""
     echo "Requirements installation failed. Please remove the venv folder and run the script again."
     deactivate

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,11 +8,11 @@ RUN apt-get update && \
 WORKDIR /Whisper-WebUI
 
 COPY backend/ backend/
-COPY requirements.txt requirements.txt
+COPY requirements.txt constraints.txt ./
 
 RUN python3 -m venv venv && \
     . venv/bin/activate && \
-    pip install -U -r backend/requirements-backend.txt
+    PIP_CONSTRAINT=constraints.txt PIP_BUILD_CONSTRAINT=constraints.txt pip install -U -r backend/requirements-backend.txt
 
 
 FROM debian:bookworm-slim AS runtime

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,8 @@
+# jhj0517-whisper's setup.py imports pkg_resources, which setuptools no longer ships. pip builds
+# that dependency in an isolated environment which always picks the newest setuptools, so pinning
+# it in the target environment has no effect -- it has to be applied as a constraint.
+#
+# Point both PIP_CONSTRAINT and PIP_BUILD_CONSTRAINT at this file wherever the requirements are
+# installed. pip >= 26 deliberately ignores PIP_CONSTRAINT inside an isolated build and honours
+# only PIP_BUILD_CONSTRAINT; older pip has no PIP_BUILD_CONSTRAINT and honours PIP_CONSTRAINT.
+setuptools<81


### PR DESCRIPTION
`pip install -r requirements.txt` fails before it downloads anything:

    Getting requirements to build wheel: finished with status 'error'
    ModuleNotFoundError: No module named 'pkg_resources'

jhj0517-whisper's setup.py imports pkg_resources, which recent setuptools no longer ships. pip builds it in an isolated environment that always takes the newest setuptools, so pinning it in the venv has no effect -- the constraint has to reach the build env, which is what PIP_CONSTRAINT does.

Both images install that dependency, so both need it.
