### PR TITLE
feat: save and load settings as presets in the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ outputs/
 models/
 modules/yt_tmp.wav
 configs/default_parameters.yaml
+configs/presets/

--- a/app.py
+++ b/app.py
@@ -8,6 +8,9 @@ from modules.utils.paths import (FASTER_WHISPER_MODELS_DIR, DIARIZATION_MODELS_D
                                  INSANELY_FAST_WHISPER_MODELS_DIR, NLLB_MODELS_DIR, DEFAULT_PARAMETERS_CONFIG_PATH,
                                  UVR_MODELS_DIR, I18N_YAML_PATH)
 from modules.utils.files_manager import load_yaml, MEDIA_EXTENSION
+from modules.utils.preset_manager import (list_presets, load_preset, save_preset, delete_preset,
+                                          sanitize_preset_name, pipeline_values_to_preset,
+                                          preset_to_pipeline_values, keep_available_choices)
 from modules.whisper.whisper_factory import WhisperFactory
 from modules.translation.nllb_inference import NLLBInference
 from modules.ui.htmls import *
@@ -41,6 +44,8 @@ class App:
         self.deepl_api = DeepLAPI(
             output_dir=os.path.join(self.args.output_dir, "translations")
         )
+        self.preset_dropdowns = []
+        self.preset_events = []
         self.i18n = load_yaml(I18N_YAML_PATH)
         self.default_params = load_yaml(DEFAULT_PARAMETERS_CONFIG_PATH)
         logger.info(f"Use \"{self.args.whisper_type}\" implementation\n"
@@ -51,6 +56,15 @@ class App:
         vad_params = self.default_params["vad"]
         diarization_params = self.default_params["diarization"]
         uvr_params = self.default_params["bgm_separation"]
+
+        with gr.Row(equal_height=True):
+            dd_preset = gr.Dropdown(choices=list_presets(), value=None, label=_("Preset"),
+                                    info=_("Save the settings below as a preset, or load a saved one"),
+                                    allow_custom_value=True, scale=4)
+            self.preset_dropdowns.append(dd_preset)
+            btn_preset_load = gr.Button(_("LOAD"), scale=1)
+            btn_preset_save = gr.Button(_("SAVE"), scale=1)
+            btn_preset_delete = gr.Button(_("DELETE"), scale=1)
 
         with gr.Row():
             dd_model = gr.Dropdown(choices=self.whisper_inf.available_models, value=whisper_params["model_size"],
@@ -89,11 +103,72 @@ class App:
 
         pipeline_inputs = [dd_model, dd_lang, cb_translate] + whisper_inputs + vad_inputs + diarization_inputs + uvr_inputs
 
+        # The preset holds whatever is in the UI right now, so every handler takes the pipeline
+        # inputs and gives them back. Each tab builds its own widgets, hence its own wiring.
+        preset_params = [dd_file_format, cb_timestamp] + pipeline_inputs
+
+        def on_preset_load(preset_name, file_format, add_timestamp, *pipeline_values):
+            try:
+                preset = load_preset(preset_name)
+            except (ValueError, FileNotFoundError, OSError) as e:
+                raise gr.Error(str(e))
+
+            whisper_preset = preset.get("whisper") or {}
+            current_values = [file_format, add_timestamp] + list(pipeline_values)
+            values = [whisper_preset.get("file_format", file_format),
+                      whisper_preset.get("add_timestamp", add_timestamp)] + \
+                preset_to_pipeline_values(preset, list(pipeline_values))
+
+            gr.Info(_("Loaded preset") + f" : {sanitize_preset_name(preset_name)}")
+            return keep_available_choices(preset_params, values, current_values)
+
+        btn_preset_load.click(fn=on_preset_load, inputs=[dd_preset] + preset_params,
+                              outputs=preset_params)
+        # Saving and deleting change the list every tab shows, so they are wired in `launch()`
+        # once the other tabs exist. Loading only touches this tab, so it is wired here.
+        self.preset_events.append((dd_preset, btn_preset_save, btn_preset_delete, preset_params))
+
         return (
             pipeline_inputs,
             dd_file_format,
             cb_timestamp
         )
+
+    def preset_choices(self, selected: str = None, selected_index: int = None):
+        """
+        Update every tab's preset dropdown. Only the tab that was used gets its selection changed;
+        the others just get the new list, so they keep whatever they had selected.
+        """
+        presets = list_presets()
+        return [gr.Dropdown(choices=presets, value=selected) if index == selected_index
+                else gr.Dropdown(choices=presets)
+                for index in range(len(self.preset_dropdowns))]
+
+    def preset_saver(self, index: int):
+        """Build the SAVE handler for one tab. `index` is the dropdown that keeps the selection."""
+        def on_preset_save(preset_name, file_format, add_timestamp, *pipeline_values):
+            try:
+                preset_name = sanitize_preset_name(preset_name)
+                save_preset(preset_name, pipeline_values_to_preset(list(pipeline_values),
+                                                                   file_format, add_timestamp))
+            except (ValueError, OSError) as e:
+                raise gr.Error(str(e))
+
+            gr.Info(_("Saved preset") + f" : {preset_name}")
+            return self.preset_choices(selected=preset_name, selected_index=index)
+        return on_preset_save
+
+    def preset_deleter(self, index: int):
+        """Build the DELETE handler for one tab."""
+        def on_preset_delete(preset_name):
+            try:
+                delete_preset(preset_name)
+            except (ValueError, FileNotFoundError, OSError) as e:
+                raise gr.Error(str(e))
+
+            gr.Info(_("Deleted preset") + f" : {sanitize_preset_name(preset_name)}")
+            return self.preset_choices(selected=None, selected_index=index)
+        return on_preset_delete
 
     def launch(self):
         translation_params = self.default_params["translation"]
@@ -302,6 +377,21 @@ class App:
                                                      fn=lambda: self.open_folder(os.path.join(
                                                          self.args.output_dir, "UVR", "vocals"
                                                      )))
+
+            # Every tab builds its own dropdown, so saving or deleting has to write to all of
+            # them, which is only possible now that they all exist.
+            for index, (dd_preset, btn_save, btn_delete, preset_params) in enumerate(self.preset_events):
+                btn_save.click(fn=self.preset_saver(index), inputs=[dd_preset] + preset_params,
+                               outputs=self.preset_dropdowns)
+                btn_delete.click(fn=self.preset_deleter(index), inputs=dd_preset,
+                                 outputs=self.preset_dropdowns)
+
+            # Presets can also appear or disappear on disk while the app runs, and the choices are
+            # baked in when the UI is built, so refresh them whenever a page loads. Don't do this
+            # on the dropdown's own focus event: a `choices` update re-filters the list against the
+            # text in the box, which would hide every preset but the selected one.
+            self.app.load(fn=lambda: self.preset_choices(), inputs=None,
+                          outputs=self.preset_dropdowns)
 
         # Launch the app with optional gradio settings
         args = self.args

--- a/modules/utils/paths.py
+++ b/modules/utils/paths.py
@@ -10,6 +10,7 @@ DIARIZATION_MODELS_DIR = os.path.join(MODELS_DIR, "Diarization")
 UVR_MODELS_DIR = os.path.join(MODELS_DIR, "UVR", "MDX_Net_Models")
 CONFIGS_DIR = os.path.join(WEBUI_DIR, "configs")
 DEFAULT_PARAMETERS_CONFIG_PATH = os.path.join(CONFIGS_DIR, "default_parameters.yaml")
+PRESETS_DIR = os.path.join(CONFIGS_DIR, "presets")
 I18N_YAML_PATH = os.path.join(CONFIGS_DIR, "translation.yaml")
 OUTPUT_DIR = os.path.join(WEBUI_DIR, "outputs")
 TRANSLATION_OUTPUT_DIR = os.path.join(OUTPUT_DIR, "translations")
@@ -29,6 +30,7 @@ for dir_path in [MODELS_DIR,
                  DIARIZATION_MODELS_DIR,
                  UVR_MODELS_DIR,
                  CONFIGS_DIR,
+                 PRESETS_DIR,
                  OUTPUT_DIR,
                  TRANSLATION_OUTPUT_DIR,
                  UVR_INSTRUMENTAL_OUTPUT_DIR,

--- a/modules/utils/preset_manager.py
+++ b/modules/utils/preset_manager.py
@@ -1,0 +1,132 @@
+import os
+import re
+from copy import deepcopy
+from typing import Dict, List, Optional
+
+from modules.utils.constants import AUTOMATIC_DETECTION, GRADIO_NONE_NUMBER_MAX
+from modules.utils.files_manager import load_yaml, save_yaml
+from modules.utils.paths import PRESETS_DIR
+from modules.whisper.data_classes import (BGMSeparationParams, DiarizationParams, VadParams, WhisperParams)
+
+PRESET_EXTENSION = ".yaml"
+
+# The pipeline inputs are passed around as a flat list of gradio values, ordered the same way as
+# `TranscriptionPipelineParams.to_list()` : one section after another, each in `model_fields` order.
+PIPELINE_SECTIONS = (
+    ("whisper", WhisperParams),
+    ("vad", VadParams),
+    ("diarization", DiarizationParams),
+    ("bgm_separation", BGMSeparationParams),
+)
+
+
+def sanitize_preset_name(name: str) -> str:
+    """A preset name is used as a file name, so keep it to something safe."""
+    name = os.path.basename(name.strip()) if isinstance(name, str) else ""
+    name = re.sub(r"[^\w\-. ]", "_", name).strip(" .")
+    if not name:
+        raise ValueError("Please enter a valid preset name.")
+    return name
+
+
+def get_preset_path(name: str) -> str:
+    return os.path.join(PRESETS_DIR, sanitize_preset_name(name) + PRESET_EXTENSION)
+
+
+def list_presets() -> List[str]:
+    if not os.path.isdir(PRESETS_DIR):
+        return []
+    return sorted(os.path.splitext(file)[0] for file in os.listdir(PRESETS_DIR)
+                  if file.endswith(PRESET_EXTENSION))
+
+
+def load_preset(name: str) -> Dict:
+    path = get_preset_path(name)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"There's no preset named \"{name}\".")
+    return load_yaml(path) or {}
+
+
+def save_preset(name: str, data: Dict) -> str:
+    os.makedirs(PRESETS_DIR, exist_ok=True)
+    return save_yaml(data, get_preset_path(name))
+
+
+def delete_preset(name: str) -> None:
+    path = get_preset_path(name)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"There's no preset named \"{name}\".")
+    os.remove(path)
+
+
+def pipeline_values_to_preset(pipeline_values: List,
+                              file_format: Optional[str] = None,
+                              add_timestamp: Optional[bool] = None) -> Dict:
+    """
+    Convert the values that are currently in the UI into a preset.
+
+    The values are stored exactly as the gradio components hold them, so a preset file has the same
+    schema as `configs/default_parameters.yaml` and loading one back restores the UI as it was.
+    """
+    preset, index = {}, 0
+    for section, params in PIPELINE_SECTIONS:
+        field_names = list(params.model_fields.keys())
+        preset[section] = dict(zip(field_names, pipeline_values[index:index + len(field_names)]))
+        index += len(field_names)
+
+    if file_format is not None:
+        preset["whisper"]["file_format"] = file_format
+    if add_timestamp is not None:
+        preset["whisper"]["add_timestamp"] = add_timestamp
+    return preset
+
+
+def preset_to_pipeline_values(preset: Dict, current_values: List) -> List:
+    """
+    Convert a preset back into the flat list of gradio values.
+
+    Fields that the preset doesn't have keep the value they currently have in the UI, so that a
+    preset written by an older version doesn't wipe the parameters it doesn't know about.
+    """
+    preset = normalize_preset(preset)
+
+    values, index = [], 0
+    for section, params in PIPELINE_SECTIONS:
+        cached = preset.get(section) or {}
+        for field_name in params.model_fields:
+            values.append(cached[field_name] if field_name in cached else current_values[index])
+            index += 1
+    return values
+
+
+def keep_available_choices(components: List, values: List, current_values: List) -> List:
+    """
+    A preset that was copied from another machine can name a device, a compute type or a model size
+    that this one doesn't have. Those keep the value the UI already has instead of being restored.
+    """
+    for index, component in enumerate(components):
+        choices = [choice for _, choice in getattr(component, "choices", None) or []]
+        if (choices and not getattr(component, "allow_custom_value", False)
+                and values[index] not in choices):
+            values[index] = current_values[index]
+    return values
+
+
+def normalize_preset(preset: Dict) -> Dict:
+    """
+    Convert the values that can't be displayed as they are in the UI, mirroring
+    `BaseTranscriptionPipeline.cache_parameters()`. Only hand written presets need this.
+    """
+    preset = deepcopy(preset)
+    whisper_preset, vad_preset = preset.get("whisper") or {}, preset.get("vad") or {}
+
+    if "lang" in whisper_preset and whisper_preset["lang"] is None:
+        whisper_preset["lang"] = AUTOMATIC_DETECTION.unwrap()
+
+    if isinstance(whisper_preset.get("suppress_tokens", None), list):
+        whisper_preset["suppress_tokens"] = str(whisper_preset["suppress_tokens"])
+
+    if vad_preset.get("max_speech_duration_s", None) == float("inf"):
+        vad_preset["max_speech_duration_s"] = GRADIO_NONE_NUMBER_MAX
+
+    return preset

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -1,0 +1,155 @@
+import os
+import pytest
+
+from modules.utils.constants import AUTOMATIC_DETECTION, GRADIO_NONE_NUMBER_MAX, GRADIO_NONE_STR
+from modules.utils.paths import PRESETS_DIR
+from modules.utils.preset_manager import *
+from modules.whisper.data_classes import (BGMSeparationParams, DiarizationParams, TranscriptionPipelineParams,
+                                          VadParams, WhisperParams)
+
+TEST_PRESET_NAME = "test-preset"
+
+
+def ui_values(**overrides):
+    """The values as the gradio components hold them, which is what a preset is made of."""
+    whisper = WhisperParams().to_dict()
+    whisper.update(model_size="large-v3", lang="japanese", compute_type="int8_float32",
+                   condition_on_previous_text=False, compression_ratio_threshold=2.0,
+                   hallucination_silence_threshold=2.0, initial_prompt=GRADIO_NONE_STR,
+                   prefix=GRADIO_NONE_STR, hotwords=GRADIO_NONE_STR, suppress_tokens="[-1]",
+                   max_new_tokens=0)
+    vad = VadParams().to_dict()
+    vad.update(vad_filter=True, max_speech_duration_s=30)
+    diarization = DiarizationParams().to_dict()
+    bgm_separation = BGMSeparationParams().to_dict()
+    bgm_separation.update(is_separate_bgm=True)
+
+    values = list(whisper.values()) + list(vad.values()) + list(diarization.values()) + \
+        list(bgm_separation.values())
+    for index, value in overrides.items():
+        values[index] = value
+    return values
+
+
+@pytest.fixture(autouse=True)
+def clean_preset():
+    yield
+    path = os.path.join(PRESETS_DIR, TEST_PRESET_NAME + PRESET_EXTENSION)
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def test_preset_round_trip():
+    values = ui_values()
+
+    save_preset(TEST_PRESET_NAME, pipeline_values_to_preset(values, file_format="WebVTT",
+                                                            add_timestamp=True))
+    assert TEST_PRESET_NAME in list_presets()
+
+    preset = load_preset(TEST_PRESET_NAME)
+    assert preset["whisper"]["file_format"] == "WebVTT"
+    assert preset["whisper"]["add_timestamp"] is True
+    assert preset["whisper"]["lang"] == "japanese"
+    assert preset["vad"]["max_speech_duration_s"] == 30
+    assert preset["bgm_separation"]["is_separate_bgm"] is True
+
+    # Every widget is restored to what it was, without going through the UI's current values
+    assert preset_to_pipeline_values(preset, [None] * len(values)) == values
+
+    delete_preset(TEST_PRESET_NAME)
+    assert TEST_PRESET_NAME not in list_presets()
+
+
+def test_preset_is_usable_by_the_pipeline():
+    """A preset is made of raw UI values, so it has to survive the same conversion a job does."""
+    values = preset_to_pipeline_values(
+        pipeline_values_to_preset(ui_values()), [None] * len(ui_values())
+    )
+    params = TranscriptionPipelineParams.from_list(values)
+
+    assert params.whisper.model_size == "large-v3"
+    assert params.whisper.suppress_tokens == [-1]
+    assert params.vad.max_speech_duration_s == 30
+    assert params.bgm_separation.is_separate_bgm is True
+
+
+def test_preset_keeps_current_values_for_unknown_fields():
+    """A preset written by an older version shouldn't wipe the parameters it doesn't know about."""
+    preset = pipeline_values_to_preset(ui_values())
+    del preset["whisper"]["model_size"]
+    del preset["vad"]
+    del preset["bgm_separation"]["is_separate_bgm"]
+
+    current = ui_values()
+    current[0] = "tiny"  # whisper.model_size
+    restored = preset_to_pipeline_values(preset, current)
+
+    assert restored[0] == "tiny"
+    vad_index = len(WhisperParams.model_fields)
+    assert restored[vad_index:vad_index + len(VadParams.model_fields)] == \
+        current[vad_index:vad_index + len(VadParams.model_fields)]
+    assert restored == current
+
+
+def test_hand_written_preset_is_normalized_for_the_ui():
+    preset = pipeline_values_to_preset(ui_values())
+    preset["whisper"]["lang"] = None
+    preset["whisper"]["suppress_tokens"] = [-1]
+    preset["vad"]["max_speech_duration_s"] = float("inf")
+
+    values = preset_to_pipeline_values(preset, [None] * len(ui_values()))
+    field_names = list(WhisperParams.model_fields.keys())
+
+    assert values[field_names.index("lang")] == AUTOMATIC_DETECTION.unwrap()
+    assert values[field_names.index("suppress_tokens")] == "[-1]"
+    assert values[len(field_names) + list(VadParams.model_fields.keys()).index(
+        "max_speech_duration_s")] == GRADIO_NONE_NUMBER_MAX
+
+
+def test_preset_name_is_safe_to_use_as_a_file_name():
+    assert sanitize_preset_name("  music anime  ") == "music anime"
+    assert sanitize_preset_name("../../etc/passwd") == "passwd"
+    assert os.path.dirname(get_preset_path("a/b")) == PRESETS_DIR
+
+    for invalid_name in ["", "   ", None, "..", "/"]:
+        with pytest.raises(ValueError):
+            sanitize_preset_name(invalid_name)
+
+
+def test_missing_preset_raises():
+    with pytest.raises(FileNotFoundError):
+        load_preset("this-preset-does-not-exist")
+    with pytest.raises(FileNotFoundError):
+        delete_preset("this-preset-does-not-exist")
+
+
+def test_pipeline_inputs_match_the_preset_sections():
+    """
+    A preset maps the flat list of gradio values onto the params by position, so the widgets have to
+    stay in `model_fields` order. `TranscriptionPipelineParams.from_list()` relies on this too.
+    """
+    whisper_inputs = WhisperParams.to_gradio_inputs(defaults={}, only_advanced=True,
+                                                    available_compute_types=["float32"],
+                                                    compute_type="float32")
+    # `only_advanced` skips model_size, lang and is_translate, which the UI builds separately
+    assert 3 + len(whisper_inputs) == len(WhisperParams.model_fields)
+    assert len(VadParams.to_gradio_inputs(defaults={})) == len(VadParams.model_fields)
+    assert len(DiarizationParams.to_gradio_inputs(defaults={}, available_devices=["cpu"],
+                                                  device="cpu")) == len(DiarizationParams.model_fields)
+    assert len(BGMSeparationParams.to_gradio_input(defaults={}, available_devices=["cpu"], device="cpu",
+                                                   available_models=["UVR-MDX-NET-Inst_HQ_4"])) == \
+        len(BGMSeparationParams.model_fields)
+
+
+def test_values_this_machine_cant_offer_are_left_alone():
+    """A preset copied from a machine with a GPU shouldn't put "cuda" in a CPU only dropdown."""
+    import gradio as gr
+
+    components = [gr.Dropdown(choices=["cpu", "cuda"], value="cpu"),
+                  gr.Dropdown(choices=["float32"], value="float32"),
+                  gr.Dropdown(choices=["large-v2"], value="large-v2", allow_custom_value=True),
+                  gr.Number(value=5)]
+    values = keep_available_choices(components, ["cuda", "int8_float32", "large-v3", 3],
+                                    ["cpu", "float32", "large-v2", 5])
+
+    assert values == ["cuda", "float32", "large-v3", 3]


### PR DESCRIPTION
The settings model is last-run-wins: `cache_parameters()` overwrites `configs/default_parameters.yaml` after every job, and `app.py` only reads that file at process start. So there is no way to keep more than one set of settings for different kinds of media, and no way to switch without a restart.

Add a preset row to `create_pipeline_inputs()`, so all three tabs get it, each wired to its own widgets. A preset holds whatever is in the UI at that moment, not what is in `default_parameters.yaml` -- no job has to run first.

The values are stored exactly as the gradio components hold them, so a preset file has the same schema as `default_parameters.yaml` and the round trip is lossless. Fields the preset doesn't have keep their current value in the UI, and a value this machine can't offer (a device or a compute type from a preset that was copied from another machine) is left alone rather than forced into a dropdown.
